### PR TITLE
CI: bump actions/checkout to v6 and actions/cache to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build & Test
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Show Xcode version
         run: xcodebuild -version
@@ -53,7 +53,7 @@ jobs:
     name: Security Audit
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check for hardcoded secrets
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
       # reused across releases. Keyed on Package.resolved; restore-keys give
       # partial reuse so only changed sources recompile.
       - name: Cache SwiftPM .build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}


### PR DESCRIPTION
The release run for v1.11.4 warned that `actions/checkout@v4` and `actions/cache@v4` run on Node.js 20, which GitHub forces to Node 24 starting June 16, 2026 (and removes from runners September 16, 2026). Bumps to the current majors (`checkout@v6`, `cache@v5`), both Node 24 native. Workflow-only change, no version bump per the PR #64 precedent. This PR's own CI run exercises the new checkout version.