### PR TITLE
Cask: fix deprecated depends_on macos format

### DIFF
--- a/Casks/mac-sai.rb
+++ b/Casks/mac-sai.rb
@@ -15,7 +15,9 @@ cask "mac-sai" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :sonoma"
+  # Symbol form means "this release or newer"; the old comparison-string
+  # form (">= :sonoma") is deprecated by Homebrew and warns on every install.
+  depends_on macos: :sonoma
 
   app "Mac Sai.app"
 


### PR DESCRIPTION
Homebrew warns on every install/upgrade: `Calling string comparison format for depends_on macos: is deprecated! Use depends_on macos: :sonoma instead.` Switches the template to the symbol form (same semantics: Sonoma or newer). The live tap cask gets the same fix pushed directly so users stop seeing the warning before the next release. Metadata-only, no version bump.