### PR TITLE
feat(optimization): revamp optimization page, fix login item detectio…

### DIFF
--- a/Sources/MacClean/Modules/Optimization/FileHandlerEntry.swift
+++ b/Sources/MacClean/Modules/Optimization/FileHandlerEntry.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct HandlerEntry: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public var contentType: String?
+    public var contentTag: String?
+    public var contentTagClass: String?
+    public var roleAll: String?
+    public var urlScheme: String?
+    public var modificationDate: Date?
+
+    public var fileTypeDescription: String {
+        if let ct = contentType {
+            return ct
+        } else if let tag = contentTag, let cls = contentTagClass {
+            if cls.contains("filename-extension") { return ".\(tag)" }
+            return tag
+        } else if let scheme = urlScheme {
+            return "\(scheme)://"
+        }
+        return "Unknown"
+    }
+
+    public var appBundleIdentifier: String? { roleAll }
+}

--- a/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
+++ b/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
@@ -1,20 +1,43 @@
 import Foundation
 import AppKit
 
+public enum LaunchServicesError: LocalizedError, Sendable {
+    case backupFailed(Error)
+    case restoreFailed(Error)
+    case deleteFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .backupFailed(let e): return "Backup failed: \(e.localizedDescription)"
+        case .restoreFailed(let e): return "Restore failed: \(e.localizedDescription)"
+        case .deleteFailed(let msg): return "Delete failed: \(msg)"
+        }
+    }
+}
+
 public final class LaunchServicesService: @unchecked Sendable {
     public static let shared = LaunchServicesService()
 
     private let plistPath: String
+    private let backupDir: URL
 
     private init() {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         plistPath = "\(home)/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+        backupDir = URL(fileURLWithPath: home)
+            .appending(path: "Library/Application Support/MacClean/LaunchServicesBackups")
+        try? FileManager.default.createDirectory(at: backupDir, withIntermediateDirectories: true)
     }
 
     /// Testing override: inject a custom plist path so tests don't touch the real file.
     internal init(plistPath: String) {
         self.plistPath = plistPath
+        backupDir = URL(fileURLWithPath: plistPath).deletingLastPathComponent()
+            .appending(path: ".launchservices-backups")
+        try? FileManager.default.createDirectory(at: backupDir, withIntermediateDirectories: true)
     }
+
+    // MARK: - Read
 
     public func loadHandlers() -> [HandlerEntry] {
         guard FileManager.default.fileExists(atPath: plistPath),
@@ -37,24 +60,108 @@ public final class LaunchServicesService: @unchecked Sendable {
         }
     }
 
-    public func saveHandlers(_ handlers: [HandlerEntry]) throws {
-        let arr: [[String: Any]] = handlers.map { entry in
-            var dict: [String: Any] = [:]
-            dict["LSHandlerContentType"] = entry.contentType
-            dict["LSHandlerContentTag"] = entry.contentTag
-            dict["LSHandlerContentTagClass"] = entry.contentTagClass
-            dict["LSHandlerRoleAll"] = entry.roleAll
-            dict["LSHandlerURLScheme"] = entry.urlScheme
-            if let md = entry.modificationDate {
-                dict["LSHandlerModificationDate"] = md.timeIntervalSince1970
-            }
-            dict["LSHandlerPreferredVersions"] = ["LSHandlerRoleAll": "-"]
-            return dict
+    // MARK: - Safe Delete (in-place with backup)
+
+    /// Delete a single entry from LSHandlers.  Before mutating it backs up the
+    /// current plist so every change is reversible.
+    public func deleteHandler(_ entry: HandlerEntry) throws {
+        // 1. Backup first — always.
+        try backup()
+
+        // 2. Read as mutable dictionary so unknown keys are preserved.
+        guard let plistData = NSMutableDictionary(contentsOfFile: plistPath) else {
+            throw LaunchServicesError.deleteFailed("Cannot read plist")
         }
-        let plist: [String: Any] = ["LSHandlers": arr]
-        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
-        try data.write(to: URL(fileURLWithPath: plistPath))
+
+        if let handlers = plistData["LSHandlers"] as? NSMutableArray {
+            let indices = (0 ..< handlers.count)
+                .filter { i in
+                    guard let dict = handlers[i] as? [String: Any] else { return false }
+                    return entryMatches(entry, dict)
+                }
+                .reversed()
+            for idx in indices {
+                handlers.removeObject(at: idx)
+            }
+        }
+
+        guard plistData.write(toFile: plistPath, atomically: true) else {
+            throw LaunchServicesError.deleteFailed("Cannot write plist")
+        }
     }
+
+    // MARK: - Backup / Restore
+
+    /// Snapshot the current plist to the backup directory.
+    public func backup() throws {
+        let src = URL(fileURLWithPath: plistPath)
+        guard FileManager.default.fileExists(atPath: plistPath) else { return }
+        let fm = ISO8601DateFormatter()
+        fm.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let ts = fm.string(from: Date())
+            // Replace colons with underscores so the name is filesystem-safe
+            // and trivially reversible for display.
+            .replacingOccurrences(of: ":", with: "_")
+        var dst = backupDir.appending(path: "launchservices-\(ts).plist")
+        // If two backups happen in the same fractional second, append a uniquifier.
+        if FileManager.default.fileExists(atPath: dst.path) {
+            dst = backupDir.appending(path: "launchservices-\(ts)-\(UUID().uuidString.prefix(8)).plist")
+        }
+        do {
+            try FileManager.default.copyItem(at: src, to: dst)
+        } catch {
+            throw LaunchServicesError.backupFailed(error)
+        }
+    }
+
+    /// List available backups newest-first (sorted by filename timestamp).
+    public func listBackups() -> [URL] {
+        guard let contents = try? FileManager.default
+            .contentsOfDirectory(at: backupDir,
+                                includingPropertiesForKeys: nil)
+        else { return [] }
+        return contents
+            .filter { $0.pathExtension == "plist" }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+    }
+
+    /// Restore a specific backup to the live plist path, replacing the current.
+    public func restoreBackup(from url: URL) throws {
+        let dst = URL(fileURLWithPath: plistPath)
+        do {
+            // Remove current, then copy backup in its place.
+            if FileManager.default.fileExists(atPath: plistPath) {
+                try FileManager.default.removeItem(at: dst)
+            }
+            try FileManager.default.copyItem(at: url, to: dst)
+        } catch {
+            throw LaunchServicesError.restoreFailed(error)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Check whether a plist dictionary matches a HandlerEntry.
+    private func entryMatches(_ entry: HandlerEntry, _ dict: [String: Any]) -> Bool {
+        // Match on URL scheme when present.
+        if let scheme = entry.urlScheme {
+            return dict["LSHandlerURLScheme"] as? String == scheme
+        }
+        // Match on content-type + roleAll when present.
+        if let ct = entry.contentType {
+            return dict["LSHandlerContentType"] as? String == ct
+                && dict["LSHandlerRoleAll"] as? String == entry.roleAll
+        }
+        // Fallback: match on content-tag + tag-class + roleAll.
+        if let tag = entry.contentTag {
+            return dict["LSHandlerContentTag"] as? String == tag
+                && dict["LSHandlerContentTagClass"] as? String == entry.contentTagClass
+                && dict["LSHandlerRoleAll"] as? String == entry.roleAll
+        }
+        return false
+    }
+
+    // MARK: - App Info
 
     public func getAppInfo(for bundleId: String?) -> (name: String, icon: NSImage)? {
         guard let bid = bundleId, !bid.isEmpty,

--- a/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
+++ b/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
@@ -1,0 +1,76 @@
+import Foundation
+import AppKit
+
+public final class LaunchServicesService: @unchecked Sendable {
+    public static let shared = LaunchServicesService()
+
+    private let plistPath: String
+
+    private init() {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        plistPath = "\(home)/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
+    }
+
+    public func loadHandlers() -> [HandlerEntry] {
+        guard FileManager.default.fileExists(atPath: plistPath),
+              let plistData = NSDictionary(contentsOfFile: plistPath),
+              let handlers = plistData["LSHandlers"] as? [[String: Any]] else {
+            return []
+        }
+        return handlers.compactMap { dict -> HandlerEntry? in
+            var entry = HandlerEntry(id: UUID())
+            entry.contentType = dict["LSHandlerContentType"] as? String
+            entry.contentTag = dict["LSHandlerContentTag"] as? String
+            entry.contentTagClass = dict["LSHandlerContentTagClass"] as? String
+            entry.roleAll = dict["LSHandlerRoleAll"] as? String
+            entry.urlScheme = dict["LSHandlerURLScheme"] as? String
+            if let ts = dict["LSHandlerModificationDate"] as? Double {
+                entry.modificationDate = Date(timeIntervalSince1970: ts)
+            }
+            if entry.roleAll == nil && entry.urlScheme == nil { return nil }
+            return entry
+        }
+    }
+
+    public func saveHandlers(_ handlers: [HandlerEntry]) throws {
+        let arr: [[String: Any]] = handlers.map { entry in
+            var dict: [String: Any] = [:]
+            dict["LSHandlerContentType"] = entry.contentType
+            dict["LSHandlerContentTag"] = entry.contentTag
+            dict["LSHandlerContentTagClass"] = entry.contentTagClass
+            dict["LSHandlerRoleAll"] = entry.roleAll
+            dict["LSHandlerURLScheme"] = entry.urlScheme
+            if let md = entry.modificationDate {
+                dict["LSHandlerModificationDate"] = md.timeIntervalSince1970
+            }
+            dict["LSHandlerPreferredVersions"] = ["LSHandlerRoleAll": "-"]
+            return dict
+        }
+        let plist: [String: Any] = ["LSHandlers": arr]
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try data.write(to: URL(fileURLWithPath: plistPath))
+    }
+
+    public func getAppInfo(for bundleId: String?) -> (name: String, icon: NSImage)? {
+        guard let bid = bundleId, !bid.isEmpty,
+              let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bid) else {
+            return nil
+        }
+        let name = FileManager.default.displayName(atPath: url.path)
+        let icon = NSWorkspace.shared.icon(forFile: url.path)
+        icon.size = NSSize(width: 32, height: 32)
+        return (name, icon)
+    }
+
+    public func getURLSchemeAppInfo(for scheme: String?) -> (name: String, icon: NSImage)? {
+        guard let s = scheme, !s.isEmpty,
+              let url = URL(string: "\(s)://test"),
+              let appURL = NSWorkspace.shared.urlForApplication(toOpen: url) else {
+            return nil
+        }
+        let name = FileManager.default.displayName(atPath: appURL.path)
+        let icon = NSWorkspace.shared.icon(forFile: appURL.path)
+        icon.size = NSSize(width: 32, height: 32)
+        return (name, icon)
+    }
+}

--- a/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
+++ b/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
@@ -11,6 +11,11 @@ public final class LaunchServicesService: @unchecked Sendable {
         plistPath = "\(home)/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist"
     }
 
+    /// Testing override: inject a custom plist path so tests don't touch the real file.
+    internal init(plistPath: String) {
+        self.plistPath = plistPath
+    }
+
     public func loadHandlers() -> [HandlerEntry] {
         guard FileManager.default.fileExists(atPath: plistPath),
               let plistData = NSDictionary(contentsOfFile: plistPath),

--- a/Sources/MacClean/Modules/Optimization/OptimizationModule.swift
+++ b/Sources/MacClean/Modules/Optimization/OptimizationModule.swift
@@ -10,120 +10,222 @@ public struct OptimizationModule: ScanModule {
     public init() {}
 
     public func scan() async -> [ScanResult] {
-        // This module doesn't produce file-based scan results.
-        // It provides live system state. Returning empty for now —
-        // the view model will query live data directly.
         []
     }
 }
 
-// MARK: - Login Items Manager
+// MARK: - Unified Auto-Start Model
 
-public final class LoginItemsManager: @unchecked Sendable {
-    public struct LoginItem: Identifiable, Sendable {
-        public let id: UUID = UUID()
-        public let name: String
-        public let path: URL
-        public let bundleIdentifier: String?
-        public var isEnabled: Bool
-    }
+public struct AutoStartItem: Identifiable, Sendable {
+    public let id = UUID()
+    public let name: String
+    public let bundleIdentifier: String?
+    public let programPath: String?
+    public let configFilePath: String?
+    public let sourceType: SourceType
+    public let isSystem: Bool
+    public var isEnabled: Bool
 
-    public init() {}
+    public enum SourceType: String, Sendable, CaseIterable {
+        case loginItem
+        case launchAgent
+        case launchDaemon
 
-    public func getLoginItems() -> [LoginItem] {
-        // Read launch agents from ~/Library/LaunchAgents
-        let launchAgentsDir = MCConstants.userLaunchAgents
-        guard let contents = try? FileManager.default.contentsOfDirectory(
-            at: launchAgentsDir,
-            includingPropertiesForKeys: nil
-        ) else { return [] }
-
-        var items: [LoginItem] = []
-        for plistURL in contents where plistURL.pathExtension == "plist" {
-            guard let data = try? Data(contentsOf: plistURL),
-                  let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
-            else { continue }
-
-            let label = plist["Label"] as? String ?? plistURL.deletingPathExtension().lastPathComponent
-            let disabled = plist["Disabled"] as? Bool ?? false
-
-            items.append(LoginItem(
-                name: label,
-                path: plistURL,
-                bundleIdentifier: plist["Label"] as? String,
-                isEnabled: !disabled
-            ))
+        public var localizedName: String {
+            switch self {
+            case .loginItem:    return L10n.tr("登录项", "Login Item")
+            case .launchAgent:  return L10n.tr("启动代理", "Launch Agent")
+            case .launchDaemon: return L10n.tr("启动守护进程", "Launch Daemon")
+            }
         }
-
-        return items
     }
 
-    public func toggleItem(_ item: LoginItem, enabled: Bool) throws {
-        guard let data = try? Data(contentsOf: item.path),
-              var plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
-        else { return }
+    public var hasConfigFile: Bool {
+        guard let p = configFilePath else { return false }
+        return !p.isEmpty
+    }
 
-        plist["Disabled"] = !enabled
-        let newData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
-        try newData.write(to: item.path)
+    public var hasAppPath: Bool {
+        guard let p = programPath else { return false }
+        return !p.isEmpty
     }
 }
 
-// MARK: - Launch Agents Manager
+// MARK: - Unified Auto-Start Manager
 
-public final class LaunchAgentsManager: @unchecked Sendable {
-    public struct LaunchAgent: Identifiable, Sendable {
-        public let id: UUID = UUID()
-        public let label: String
-        public let path: URL
-        public let program: String?
-        public let isSystem: Bool
-        public var isEnabled: Bool
-    }
-
+public final class AutoStartManager: @unchecked Sendable {
     public init() {}
 
-    public func getLaunchAgents() -> [LaunchAgent] {
-        var agents: [LaunchAgent] = []
+    // MARK: Public API
 
-        agents.append(contentsOf: scanDirectory(MCConstants.userLaunchAgents, isSystem: false))
-        agents.append(contentsOf: scanDirectory(MCConstants.systemLaunchAgents, isSystem: true))
+    public func getItems() -> [AutoStartItem] {
+        var seen = Set<String>()
+        let all = getLoginItems() + getLaunchAgents() + getLaunchDaemons()
+        return all.filter { item in
+            let key = item.bundleIdentifier ?? item.name
+            if seen.contains(key) { return false }
+            seen.insert(key)
+            return true
+        }
+    }
 
+    public func getLoginItems() -> [AutoStartItem] {
+        loadLoginItemsViaSystemEvents()
+    }
+
+    public func getLaunchAgents() -> [AutoStartItem] {
+        var agents: [AutoStartItem] = []
+        agents.append(contentsOf: scanPlistDir(MCConstants.userLaunchAgents, type: .launchAgent, isSystem: false))
+        agents.append(contentsOf: scanPlistDir(MCConstants.systemLaunchAgents, type: .launchAgent, isSystem: true))
         return agents
     }
 
-    public enum ToggleError: Error { case systemAgentReadOnly, unreadablePlist }
-
-    /// Enable/disable a *user* launch agent by flipping its `Disabled`
-    /// key — same mechanism as Login Items. System agents live in a
-    /// root-owned directory and are refused here.
-    ///
-    /// Read/parse failures are surfaced (not silently swallowed): the
-    /// function is `throws`, so a corrupt or unreadable plist throws
-    /// `unreadablePlist` rather than no-op'ing. We deliberately never
-    /// fall back to an empty dictionary — writing back `[Disabled: …]`
-    /// alone would wipe the agent's real contents.
-    public func toggleAgent(_ agent: LaunchAgent, enabled: Bool) throws {
-        if agent.isSystem { throw ToggleError.systemAgentReadOnly }
-        let data = try Data(contentsOf: agent.path)
-        guard var plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
-        else { throw ToggleError.unreadablePlist }
-        plist["Disabled"] = !enabled
-        let newData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
-        try newData.write(to: agent.path)
+    public func getLaunchDaemons() -> [AutoStartItem] {
+        scanPlistDir(MCConstants.systemLaunchDaemons, type: .launchDaemon, isSystem: true)
     }
 
-    private func scanDirectory(_ dir: URL, isSystem: Bool) -> [LaunchAgent] {
-        guard let contents = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
-        else { return [] }
+    // MARK: Toggle
 
-        var agents: [LaunchAgent] = []
-        for plistURL in contents where plistURL.pathExtension == "plist" {
-            guard let data = try? Data(contentsOf: plistURL),
+    public enum ToggleError: Error {
+        case systemItemReadOnly
+        case unreadablePlist
+        case sfltoolFailed(String)
+    }
+
+    public func toggleItem(_ item: AutoStartItem, enabled: Bool) throws {
+        switch item.sourceType {
+        case .loginItem:
+            guard let bid = item.bundleIdentifier else { return }
+            try toggleLoginItem(bundleId: bid, enabled: enabled)
+        case .launchAgent, .launchDaemon:
+            try togglePlistItem(item, enabled: enabled)
+        }
+    }
+
+    // MARK: Open in Finder
+
+    public func openConfigInFinder(_ item: AutoStartItem) {
+        guard let path = item.configFilePath else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    }
+
+    public func openAppInFinder(_ item: AutoStartItem) {
+        guard let path = item.programPath else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: path)])
+    }
+
+    // MARK: - Login Items Acquisition
+
+    /// Read login items from System Settings → General → Login Items & Extensions
+    /// via System Events (AppleScript). This is the only reliable API on macOS 15+
+    /// — sfltool dumpbtm only returns system-level items (UID -2), and the old
+    /// backgrounditems.btm plist path no longer exists.
+    private func loadLoginItemsViaSystemEvents() -> [AutoStartItem] {
+        let script = """
+        tell application "System Events"
+            set loginItemsList to {}
+            repeat with loginItem in every login item
+                set end of loginItemsList to {name:name of loginItem, path:path of loginItem, hidden:hidden of loginItem}
+            end repeat
+            return loginItemsList
+        end tell
+        """
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return []
+        }
+
+        guard process.terminationStatus == 0 else { return [] }
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: .utf8) else { return [] }
+
+        return parseOsascriptLoginItems(output)
+    }
+
+    /// Parse AppleScript output like:
+    ///   name:com.example.app, path:/Applications/Example.app, hidden:false
+    private func parseOsascriptLoginItems(_ output: String) -> [AutoStartItem] {
+        var items: [AutoStartItem] = []
+        for line in output.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+
+            // Parse key:value pairs separated by commas
+            var name: String?
+            var path: String?
+            var hidden = false
+
+            for pair in trimmed.components(separatedBy: ", ") {
+                let kv = pair.split(separator: ":", maxSplits: 1).map(String.init)
+                guard kv.count == 2 else { continue }
+                let key = kv[0].trimmingCharacters(in: .whitespaces)
+                let val = kv[1].trimmingCharacters(in: .whitespaces)
+                switch key {
+                case "name": name = val
+                case "path": path = val
+                case "hidden": hidden = (val.lowercased() == "true")
+                default: break
+                }
+            }
+
+            guard let bundleId = name, !bundleId.isEmpty else { continue }
+
+            let displayName: String
+            let resolvedPath: String?
+            if let p = path, FileManager.default.fileExists(atPath: p) {
+                var raw = FileManager.default.displayName(atPath: p)
+                if raw.hasSuffix(".app") {
+                    raw = String(raw.dropLast(4))
+                }
+                displayName = raw
+                resolvedPath = p
+            } else {
+                displayName = bundleId
+                resolvedPath = resolveAppPath(bundleId: bundleId, path: path)
+            }
+
+            items.append(AutoStartItem(
+                name: displayName,
+                bundleIdentifier: bundleId,
+                programPath: resolvedPath,
+                configFilePath: path,
+                sourceType: .loginItem,
+                isSystem: false,
+                isEnabled: true
+            ))
+        }
+        return items
+    }
+
+    @available(*, deprecated, message: "sfltool dumpbtm only shows system-level items, not user login items")
+    public func reloadLoginItemsViaSfltool() -> [AutoStartItem] { [] }
+
+    // MARK: - Launch Agents / Daemons Acquisition
+
+    private func scanPlistDir(_ dir: URL, type: AutoStartItem.SourceType, isSystem: Bool) -> [AutoStartItem] {
+        guard let contents = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else {
+            return []
+        }
+        var items: [AutoStartItem] = []
+        for url in contents where url.pathExtension == "plist" {
+            guard let data = try? Data(contentsOf: url),
                   let plist = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
             else { continue }
 
-            let label = plist["Label"] as? String ?? plistURL.deletingPathExtension().lastPathComponent
+            let label = plist["Label"] as? String ?? url.deletingPathExtension().lastPathComponent
             let program: String?
             if let prog = plist["Program"] as? String {
                 program = prog
@@ -134,15 +236,211 @@ public final class LaunchAgentsManager: @unchecked Sendable {
             }
             let disabled = plist["Disabled"] as? Bool ?? false
 
-            agents.append(LaunchAgent(
-                label: label,
-                path: plistURL,
-                program: program,
+            // Resolve a human-readable name
+            let name: String
+            if let progPath = program, let displayName = resolveAppNameFromPath(progPath) {
+                name = displayName
+            } else {
+                name = label
+            }
+
+            items.append(AutoStartItem(
+                name: name,
+                bundleIdentifier: label,
+                programPath: program,
+                configFilePath: url.path,
+                sourceType: type,
                 isSystem: isSystem,
                 isEnabled: !disabled
             ))
         }
-        return agents
+        return items
+    }
+
+    // MARK: - Helpers
+
+    private func resolveAppName(bundleId: String, path: String?) -> String? {
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+            return FileManager.default.displayName(atPath: url.path)
+        }
+        if let p = path {
+            let expanded = (p as NSString).expandingTildeInPath
+            if FileManager.default.fileExists(atPath: expanded) {
+                return FileManager.default.displayName(atPath: expanded)
+            }
+        }
+        return nil
+    }
+
+    private func resolveAppNameFromPath(_ path: String) -> String? {
+        let expanded = (path as NSString).expandingTildeInPath
+        guard FileManager.default.fileExists(atPath: expanded) else { return nil }
+        return FileManager.default.displayName(atPath: expanded)
+    }
+
+    private func resolveAppPath(bundleId: String, path: String?) -> String? {
+        if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) {
+            return url.path
+        }
+        if let p = path {
+            let expanded = (p as NSString).expandingTildeInPath
+            if FileManager.default.fileExists(atPath: expanded) {
+                return expanded
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Toggle Implementations
+
+    private func toggleLoginItem(bundleId: String, enabled: Bool) throws {
+        // Use AppleScript via System Events to add/remove the login item.
+        // This matches what System Settings → General → Login Items does.
+        let script: String
+        if enabled {
+            // When enabling, we need the app path. Look it up from bundle ID.
+            guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) else {
+                throw ToggleError.sfltoolFailed("Cannot find app for bundle ID: \(bundleId)")
+            }
+            script = """
+            tell application "System Events"
+                make new login item at end with properties {path:"\(url.path)", hidden:false}
+            end tell
+            """
+        } else {
+            script = """
+            tell application "System Events"
+                delete login item "\(bundleId)"
+            end tell
+            """
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = ["-e", script]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: data, encoding: .utf8) ?? ""
+            throw ToggleError.sfltoolFailed(output)
+        }
+    }
+
+    private func togglePlistItem(_ item: AutoStartItem, enabled: Bool) throws {
+        guard !item.isSystem else { throw ToggleError.systemItemReadOnly }
+        guard let configPath = item.configFilePath else { return }
+        let data = try Data(contentsOf: URL(fileURLWithPath: configPath))
+        guard var plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            throw ToggleError.unreadablePlist
+        }
+        plist["Disabled"] = !enabled
+        let newData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try newData.write(to: URL(fileURLWithPath: configPath))
+    }
+}
+
+// MARK: - Backward-compatible Wrappers
+
+public final class LoginItemsManager: @unchecked Sendable {
+    public struct LoginItem: Identifiable, Sendable {
+        public let id: UUID = UUID()
+        public let name: String
+        public let path: URL
+        public let bundleIdentifier: String?
+        public var isEnabled: Bool
+
+        public var asAutoStartItem: AutoStartItem {
+            AutoStartItem(
+                name: name,
+                bundleIdentifier: bundleIdentifier,
+                programPath: path.path,
+                configFilePath: path.path,
+                sourceType: .loginItem,
+                isSystem: false,
+                isEnabled: isEnabled
+            )
+        }
+    }
+
+    private let inner = AutoStartManager()
+    public init() {}
+
+    public func getLoginItems() -> [LoginItem] {
+        // Old behaviour read LaunchAgents plists as "login items" — that was
+        // incorrect.  Redirect to the new unified manager which actually reads
+        // real macOS login items.  Launch agents are now under
+        // LaunchAgentsManager / the unified AutoStartManager.
+        inner.getLoginItems().map { item in
+            LoginItem(
+                name: item.name,
+                path: URL(fileURLWithPath: item.configFilePath ?? item.programPath ?? ""),
+                bundleIdentifier: item.bundleIdentifier,
+                isEnabled: item.isEnabled
+            )
+        }
+    }
+
+    public func toggleItem(_ item: LoginItem, enabled: Bool) throws {
+        try inner.toggleItem(item.asAutoStartItem, enabled: enabled)
+    }
+}
+
+public final class LaunchAgentsManager: @unchecked Sendable {
+    public struct LaunchAgent: Identifiable, Sendable {
+        public let id: UUID = UUID()
+        public let label: String
+        public let path: URL
+        public let program: String?
+        public let isSystem: Bool
+        public var isEnabled: Bool
+
+        public var asAutoStartItem: AutoStartItem {
+            AutoStartItem(
+                name: label,
+                bundleIdentifier: label,
+                programPath: program,
+                configFilePath: path.path,
+                sourceType: .launchAgent,
+                isSystem: isSystem,
+                isEnabled: isEnabled
+            )
+        }
+    }
+
+    private let inner = AutoStartManager()
+    public init() {}
+
+    public func getLaunchAgents() -> [LaunchAgent] {
+        inner.getLaunchAgents().map { item in
+            LaunchAgent(
+                label: item.name,
+                path: URL(fileURLWithPath: item.configFilePath ?? ""),
+                program: item.programPath,
+                isSystem: item.isSystem,
+                isEnabled: item.isEnabled
+            )
+        }
+    }
+
+    public enum ToggleError: Error { case systemAgentReadOnly, unreadablePlist }
+
+    public func toggleAgent(_ agent: LaunchAgent, enabled: Bool) throws {
+        do {
+            try inner.toggleItem(agent.asAutoStartItem, enabled: enabled)
+        } catch AutoStartManager.ToggleError.systemItemReadOnly {
+            throw ToggleError.systemAgentReadOnly
+        } catch AutoStartManager.ToggleError.unreadablePlist {
+            throw ToggleError.unreadablePlist
+        } catch {
+            throw ToggleError.unreadablePlist
+        }
     }
 }
 
@@ -165,7 +463,7 @@ public final class ProcessMonitor: @unchecked Sendable {
             return ProcessInfo(
                 id: app.processIdentifier,
                 name: name,
-                cpuUsage: 0, // Would need host_processor_info for per-process CPU
+                cpuUsage: 0,
                 memoryBytes: 0,
                 isResponsive: !app.isTerminated
             )

--- a/Sources/MacClean/Modules/Optimization/OptimizationModule.swift
+++ b/Sources/MacClean/Modules/Optimization/OptimizationModule.swift
@@ -302,15 +302,23 @@ public final class AutoStartManager: @unchecked Sendable {
             guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId) else {
                 throw ToggleError.sfltoolFailed("Cannot find app for bundle ID: \(bundleId)")
             }
+            // Escape backslash and double-quote so a path like /Apps/foo".app
+            // cannot break out of the AppleScript string literal.
+            let escapedPath = url.path
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
             script = """
             tell application "System Events"
-                make new login item at end with properties {path:"\(url.path)", hidden:false}
+                make new login item at end with properties {path:"\(escapedPath)", hidden:false}
             end tell
             """
         } else {
+            let escapedId = bundleId
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
             script = """
             tell application "System Events"
-                delete login item "\(bundleId)"
+                delete login item "\(escapedId)"
             end tell
             """
         }

--- a/Sources/MacClean/ViewModels/FileHandlerViewModel.swift
+++ b/Sources/MacClean/ViewModels/FileHandlerViewModel.swift
@@ -1,0 +1,68 @@
+import Foundation
+import AppKit
+import SwiftUI
+import MacCleanKit
+
+@MainActor
+public final class FileHandlerViewModel: ObservableObject {
+    @Published public var handlers: [HandlerEntry] = []
+    @Published public var isLoading = false
+    @Published public var errorMessage: String?
+    @Published public var showError = false
+    @Published public var searchText = ""
+
+    private let service = LaunchServicesService.shared
+
+    public var filteredHandlers: [HandlerEntry] {
+        if searchText.isEmpty { return handlers }
+        let q = searchText.lowercased()
+        return handlers.filter { h in
+            if h.fileTypeDescription.lowercased().contains(q) { return true }
+            if let ct = h.contentType, ct.lowercased().contains(q) { return true }
+            if let app = getAppInfo(for: h), app.name.lowercased().contains(q) { return true }
+            if let bid = h.appBundleIdentifier, bid.lowercased().contains(q) { return true }
+            return false
+        }
+    }
+
+    public func loadHandlers() {
+        isLoading = true
+        Task.detached { [weak self] in
+            let handlers = LaunchServicesService.shared.loadHandlers()
+            await MainActor.run {
+                self?.handlers = handlers
+                self?.isLoading = false
+            }
+        }
+    }
+
+    public func deleteHandler(_ handler: HandlerEntry) {
+        guard let idx = handlers.firstIndex(of: handler) else { return }
+        handlers.remove(at: idx)
+        saveHandlers()
+    }
+
+    private func saveHandlers() {
+        let currentHandlers = handlers
+        Task.detached {
+            do {
+                try LaunchServicesService.shared.saveHandlers(currentHandlers)
+            } catch {
+                await MainActor.run { [weak self] in
+                    self?.errorMessage = L10n.tr("保存失败: \(error.localizedDescription)", "Save failed: \(error.localizedDescription)")
+                    self?.showError = true
+                }
+            }
+        }
+    }
+
+    public func getAppInfo(for handler: HandlerEntry) -> (name: String, icon: NSImage)? {
+        if let bid = handler.appBundleIdentifier {
+            return service.getAppInfo(for: bid)
+        }
+        if handler.urlScheme != nil {
+            return service.getURLSchemeAppInfo(for: handler.urlScheme)
+        }
+        return nil
+    }
+}

--- a/Sources/MacClean/ViewModels/FileHandlerViewModel.swift
+++ b/Sources/MacClean/ViewModels/FileHandlerViewModel.swift
@@ -3,13 +3,19 @@ import AppKit
 import SwiftUI
 import MacCleanKit
 
+/// View model for browsing and managing user-customised file-type and URL-scheme
+/// associations.  Every delete is preceded by a backup so all changes are
+/// reversible via the restore-history panel.
 @MainActor
 public final class FileHandlerViewModel: ObservableObject {
     @Published public var handlers: [HandlerEntry] = []
     @Published public var isLoading = false
+    @Published public var searchText = ""
     @Published public var errorMessage: String?
     @Published public var showError = false
-    @Published public var searchText = ""
+    @Published public var backups: [URL] = []
+    @Published public var showRestoreSheet = false
+    @Published public var isRestoring = false
 
     private let service = LaunchServicesService.shared
 
@@ -36,25 +42,53 @@ public final class FileHandlerViewModel: ObservableObject {
         }
     }
 
-    public func deleteHandler(_ handler: HandlerEntry) {
-        guard let idx = handlers.firstIndex(of: handler) else { return }
-        handlers.remove(at: idx)
-        saveHandlers()
-    }
+    // MARK: - Delete (with auto-backup)
 
-    private func saveHandlers() {
-        let currentHandlers = handlers
-        Task.detached {
+    public func deleteHandler(_ handler: HandlerEntry) {
+        Task.detached { [weak self] in
             do {
-                try LaunchServicesService.shared.saveHandlers(currentHandlers)
+                try LaunchServicesService.shared.deleteHandler(handler)
+                await MainActor.run {
+                    self?.loadHandlers()
+                }
             } catch {
                 await MainActor.run { [weak self] in
-                    self?.errorMessage = L10n.tr("保存失败: \(error.localizedDescription)", "Save failed: \(error.localizedDescription)")
+                    self?.errorMessage = L10n.tr("删除失败：\(error.localizedDescription)",
+                                                  "Delete failed: \(error.localizedDescription)")
                     self?.showError = true
                 }
             }
         }
     }
+
+    // MARK: - Restore
+
+    public func loadBackups() {
+        backups = service.listBackups()
+    }
+
+    public func restoreBackup(from url: URL) {
+        isRestoring = true
+        Task.detached { [weak self] in
+            do {
+                try LaunchServicesService.shared.restoreBackup(from: url)
+                await MainActor.run {
+                    self?.isRestoring = false
+                    self?.showRestoreSheet = false
+                    self?.loadHandlers()
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    self?.isRestoring = false
+                    self?.errorMessage = L10n.tr("还原失败：\(error.localizedDescription)",
+                                                  "Restore failed: \(error.localizedDescription)")
+                    self?.showError = true
+                }
+            }
+        }
+    }
+
+    // MARK: - App Info
 
     public func getAppInfo(for handler: HandlerEntry) -> (name: String, icon: NSImage)? {
         if let bid = handler.appBundleIdentifier {

--- a/Sources/MacClean/Views/Performance/FileHandlerView.swift
+++ b/Sources/MacClean/Views/Performance/FileHandlerView.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+import AppKit
+import MacCleanKit
+
+struct FileHandlerView: View {
+    @StateObject private var viewModel = FileHandlerViewModel()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Search bar
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 12))
+                TextField(L10n.tr("搜索文件类型或应用...", "Search file type or app..."),
+                          text: $viewModel.searchText)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 12))
+                if !viewModel.searchText.isEmpty {
+                    Button(action: { viewModel.searchText = "" }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.borderless)
+                }
+                Button(action: { viewModel.loadHandlers() }) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.borderless)
+                .help(L10n.tr("刷新", "Refresh"))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+
+            Divider()
+
+            if viewModel.isLoading {
+                Spacer()
+                ProgressView()
+                    .controlSize(.large)
+                    .tint(.primary)
+                Spacer()
+            } else if viewModel.handlers.isEmpty {
+                Spacer()
+                VStack(spacing: 12) {
+                    Image(systemName: "doc.badge.gearshape")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.tertiary)
+                    Text(L10n.tr("没有自定义的文件打开方式", "No custom file associations"))
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            } else if viewModel.filteredHandlers.isEmpty {
+                Spacer()
+                VStack(spacing: 12) {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.tertiary)
+                    Text(L10n.tr("没有找到匹配的结果", "No matching results"))
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            } else {
+                List {
+                    ForEach(viewModel.filteredHandlers) { handler in
+                        HandlerRowView(
+                            handler: handler,
+                            appInfo: viewModel.getAppInfo(for: handler),
+                            onDelete: { viewModel.deleteHandler(handler) }
+                        )
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .alert(L10n.tr("错误", "Error"), isPresented: $viewModel.showError) {
+            Button("OK") { viewModel.showError = false }
+        } message: {
+            Text(viewModel.errorMessage ?? L10n.tr("发生未知错误", "An unknown error occurred"))
+        }
+        .onAppear { viewModel.loadHandlers() }
+    }
+}
+
+// MARK: - Row View
+
+private struct HandlerRowView: View {
+    let handler: HandlerEntry
+    let appInfo: (name: String, icon: NSImage)?
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // App Icon
+            if let info = appInfo {
+                Image(nsImage: info.icon)
+                    .resizable()
+                    .frame(width: 28, height: 28)
+            } else {
+                Image(systemName: "app.dashed")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 28, height: 28)
+            }
+
+            // File Type
+            VStack(alignment: .leading, spacing: 2) {
+                Text(handler.fileTypeDescription)
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .lineLimit(1)
+
+                if let ct = handler.contentType {
+                    Text("UTI: \(ct)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                } else if handler.urlScheme != nil {
+                    Text(L10n.tr("URL Scheme", "URL Scheme"))
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+
+            Spacer()
+
+            // App Name
+            if let info = appInfo {
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(info.name)
+                        .font(.system(size: 13))
+                    if let bid = handler.appBundleIdentifier {
+                        Text(bid)
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .lineLimit(1)
+                    }
+                }
+            } else {
+                Text(L10n.tr("未知应用", "Unknown app"))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+
+            // Delete button
+            Button(action: onDelete) {
+                Image(systemName: "trash")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+            }
+            .buttonStyle(.borderless)
+            .help(L10n.tr("删除此关联", "Remove this association"))
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/Sources/MacClean/Views/Performance/FileHandlerView.swift
+++ b/Sources/MacClean/Views/Performance/FileHandlerView.swift
@@ -7,7 +7,7 @@ struct FileHandlerView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Search bar
+            // Top bar: search + restore button
             HStack(spacing: 8) {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(.secondary)
@@ -24,6 +24,16 @@ struct FileHandlerView: View {
                     }
                     .buttonStyle(.borderless)
                 }
+                Spacer()
+                Button(action: {
+                    viewModel.loadBackups()
+                    viewModel.showRestoreSheet = true
+                }) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.borderless)
+                .help(L10n.tr("版本历史", "Version history"))
                 Button(action: { viewModel.loadHandlers() }) {
                     Image(systemName: "arrow.clockwise")
                         .font(.system(size: 12))
@@ -77,12 +87,110 @@ struct FileHandlerView: View {
                 .listStyle(.inset)
             }
         }
+        .sheet(isPresented: $viewModel.showRestoreSheet) {
+            restoreSheet
+        }
         .alert(L10n.tr("错误", "Error"), isPresented: $viewModel.showError) {
             Button("OK") { viewModel.showError = false }
         } message: {
             Text(viewModel.errorMessage ?? L10n.tr("发生未知错误", "An unknown error occurred"))
         }
         .onAppear { viewModel.loadHandlers() }
+    }
+
+    // MARK: - Restore Sheet
+
+    private var restoreSheet: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(L10n.tr("还原版本", "Restore Version"))
+                    .font(.headline)
+                Spacer()
+                Button(action: { viewModel.showRestoreSheet = false }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.borderless)
+            }
+            .padding()
+
+            Divider()
+
+            if viewModel.backups.isEmpty {
+                VStack(spacing: 12) {
+                    Spacer()
+                    Image(systemName: "clock.badge.questionmark")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.tertiary)
+                    Text(L10n.tr("没有可用的备份", "No backups available"))
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, minHeight: 200)
+            } else {
+                List {
+                    ForEach(Array(viewModel.backups.enumerated()), id: \.offset) { _, url in
+                        BackupRowView(
+                            url: url,
+                            isRestoring: viewModel.isRestoring,
+                            onRestore: { viewModel.restoreBackup(from: url) }
+                        )
+                    }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .frame(width: 420, height: 320)
+    }
+}
+
+// MARK: - Backup Row
+
+private struct BackupRowView: View {
+    let url: URL
+    let isRestoring: Bool
+    let onRestore: () -> Void
+
+    var body: some View {
+        HStack {
+            Image(systemName: "doc.badge.clock")
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(formattedDate)
+                    .font(.system(size: 13, weight: .medium))
+                Text(url.lastPathComponent)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button(action: onRestore) {
+                Text(L10n.tr("还原", "Restore"))
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.bordered)
+            .disabled(isRestoring)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var formattedDate: String {
+        // Filename: launchservices-2026-06-26T11_12_26+08_00.plist
+        // Underscores were originally colons (filesystem-safe encoding).
+        let isoStr = url.lastPathComponent
+            .replacingOccurrences(of: "launchservices-", with: "")
+            .replacingOccurrences(of: ".plist", with: "")
+            .replacingOccurrences(of: "_", with: ":")
+        let isoFmt = ISO8601DateFormatter()
+        isoFmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFmt.date(from: isoStr) {
+            let display = DateFormatter()
+            display.dateStyle = .medium
+            display.timeStyle = .medium
+            return display.string(from: date)
+        }
+        return url.lastPathComponent
     }
 }
 
@@ -151,7 +259,7 @@ private struct HandlerRowView: View {
                     .foregroundStyle(.red)
             }
             .buttonStyle(.borderless)
-            .help(L10n.tr("删除此关联", "Remove this association"))
+            .help(L10n.tr("删除此关联（自动备份当前版本）", "Remove (auto-backup created)"))
         }
         .padding(.vertical, 2)
     }

--- a/Sources/MacClean/Views/Performance/OptimizationView.swift
+++ b/Sources/MacClean/Views/Performance/OptimizationView.swift
@@ -3,13 +3,15 @@ import MacCleanKit
 
 struct OptimizationView: View {
     @AppStorage("removeBackgroundColors") private var removeBackgroundColors = false
-    @State private var loginItems: [LoginItemsManager.LoginItem] = []
-    @State private var launchAgents: [LaunchAgentsManager.LaunchAgent] = []
+    @State private var loginItems: [AutoStartItem] = []
+    @State private var launchAgents: [AutoStartItem] = []
+    @State private var launchDaemons: [AutoStartItem] = []
     @State private var selectedTab = 0
     @State private var isLoading = true
+    @State private var showAlert = false
+    @State private var alertMessage = ""
 
-    private let loginManager = LoginItemsManager()
-    private let agentManager = LaunchAgentsManager()
+    private let manager = AutoStartManager()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -27,114 +29,191 @@ struct OptimizationView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 16)
 
-            if isLoading {
-                Spacer()
-                VStack(spacing: 12) {
-                    ProgressView()
-                        .controlSize(.large)
-                        .tint(.primary)
-                    Text(L10n.tr("正在加载项目...", "Loading items..."))
-                        .font(.system(size: 13))
-                        .foregroundStyle(.primary.opacity(0.6))
-                }
-                Spacer()
-            } else {
-                Picker(L10n.tr("分区", "Section"), selection: $selectedTab) {
-                    Text(L10n.tr("登录项", "Login Items")).tag(0)
-                    Text(L10n.tr("启动代理", "Launch Agents")).tag(1)
-                }
-                .pickerStyle(.segmented)
-                .padding(.horizontal, 24)
-                .padding(.bottom, 10)
+            Picker(L10n.tr("分区", "Section"), selection: $selectedTab) {
+                Text(L10n.tr("登录项", "Login Items")).tag(0)
+                Text(L10n.tr("启动代理", "Launch Agents")).tag(1)
+                Text(L10n.tr("启动守护进程", "Launch Daemons")).tag(2)
+                Text(L10n.tr("文件打开方式", "File Associations")).tag(3)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 10)
 
-                Group {
-                    if selectedTab == 0 {
-                        loginItemsList
-                    } else {
-                        launchAgentsList
+            Group {
+                if selectedTab == 3 {
+                    FileHandlerView()
+                } else if isLoading {
+                    VStack(spacing: 12) {
+                        Spacer()
+                        ProgressView()
+                            .controlSize(.large)
+                            .tint(.primary)
+                        Text(L10n.tr("正在加载项目...", "Loading items..."))
+                            .font(.system(size: 13))
+                            .foregroundStyle(.primary.opacity(0.6))
+                        Spacer()
+                    }
+                } else {
+                    Group {
+                        switch selectedTab {
+                        case 0:  itemList(items: loginItems)
+                        case 1:  itemList(items: launchAgents)
+                        case 2:  itemList(items: launchDaemons)
+                        default: itemList(items: loginItems)
+                        }
                     }
                 }
-                .background {
-                    if removeBackgroundColors { Color.clear }
-                    else { Rectangle().fill(.ultraThinMaterial) }
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .padding(.horizontal, 20)
-                .padding(.bottom, 20)
             }
+            .background {
+                if removeBackgroundColors { Color.clear }
+                else { Rectangle().fill(.ultraThinMaterial) }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal, 20)
+            .padding(.bottom, 20)
+        }
+        .alert(alertMessage, isPresented: $showAlert) {
+            Button("OK") { showAlert = false }
         }
         .task { refresh() }
     }
 
-    private var loginItemsList: some View {
-        List {
-            ForEach(loginItems, id: \.id) { item in
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(item.name)
-                            .font(.system(size: 13, weight: .medium))
-                        if let bid = item.bundleIdentifier {
-                            Text(bid)
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
-                        }
-                    }
-                    Spacer()
-                    Toggle("", isOn: Binding(
-                        get: { item.isEnabled },
-                        set: { newVal in
-                            try? loginManager.toggleItem(item, enabled: newVal)
+    // MARK: - Item List
+
+    @ViewBuilder
+    private func itemList(items: [AutoStartItem]) -> some View {
+        if items.isEmpty {
+            VStack(spacing: 8) {
+                Spacer()
+                Image(systemName: "tray")
+                    .font(.system(size: 32))
+                    .foregroundStyle(.tertiary)
+                Text(L10n.tr("没有找到项目", "No items found"))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        } else {
+            List {
+                ForEach(items, id: \.id) { item in
+                    ItemRow(item: item, onToggle: { newVal in
+                        do {
+                            try manager.toggleItem(item, enabled: newVal)
                             refresh()
+                        } catch {
+                            alertMessage = error.localizedDescription
+                            showAlert = true
                         }
-                    ))
-                    .toggleStyle(.switch)
+                    }, onOpenConfig: {
+                        manager.openConfigInFinder(item)
+                    })
                 }
             }
+            .listStyle(.inset)
         }
-        .listStyle(.inset)
     }
 
-    private var launchAgentsList: some View {
-        List {
-            ForEach(launchAgents, id: \.id) { agent in
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(agent.label)
-                            .font(.system(size: 13, weight: .medium))
-                        if let program = agent.program {
-                            Text(program)
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
-                                .lineLimit(1)
-                        }
-                    }
-                    Spacer()
-                    if agent.isSystem {
-                        Text(L10n.tr("系统", "System"))
-                            .font(.system(size: 10))
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(.orange.opacity(0.2))
-                            .clipShape(Capsule())
-                    } else {
-                        Toggle("", isOn: Binding(
-                            get: { agent.isEnabled },
-                            set: { newVal in
-                                try? agentManager.toggleAgent(agent, enabled: newVal)
-                                refresh()
-                            }
-                        ))
-                        .toggleStyle(.switch)
-                    }
-                }
-            }
-        }
-        .listStyle(.inset)
-    }
+    // MARK: - Refresh
 
     private func refresh() {
-        loginItems = loginManager.getLoginItems()
-        launchAgents = agentManager.getLaunchAgents()
+        loginItems = manager.getLoginItems()
+        launchAgents = manager.getLaunchAgents()
+        launchDaemons = manager.getLaunchDaemons()
         isLoading = false
+    }
+}
+
+// MARK: - Item Row
+
+private struct ItemRow: View {
+    let item: AutoStartItem
+    let onToggle: (Bool) -> Void
+    let onOpenConfig: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            // App Icon
+            if let bid = item.bundleIdentifier,
+               let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bid) {
+                Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+                    .resizable()
+                    .frame(width: 28, height: 28)
+            } else if let path = item.programPath,
+                      FileManager.default.fileExists(atPath: path) {
+                Image(nsImage: NSWorkspace.shared.icon(forFile: path))
+                    .resizable()
+                    .frame(width: 28, height: 28)
+            } else {
+                Image(systemName: "app.dashed")
+                    .font(.system(size: 20))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 28, height: 28)
+            }
+
+            // Name and subtitle
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.name)
+                    .font(.system(size: 13, weight: .medium))
+                    .lineLimit(1)
+
+                HStack(spacing: 6) {
+                    // Source type badge
+                    Text(item.sourceType.localizedName)
+                        .font(.system(size: 9, weight: .medium))
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(sourceTypeColor.opacity(0.2))
+                        .foregroundStyle(sourceTypeColor)
+                        .clipShape(Capsule())
+
+                    if item.isSystem {
+                        Text(L10n.tr("系统", "System"))
+                            .font(.system(size: 9, weight: .medium))
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 1)
+                            .background(.orange.opacity(0.2))
+                            .foregroundStyle(.orange)
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            // Toggle (or lock for read-only system items)
+            if item.sourceType != .loginItem && item.isSystem {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            } else {
+                Toggle("", isOn: Binding(
+                    get: { item.isEnabled },
+                    set: { onToggle($0) }
+                ))
+                .toggleStyle(.switch)
+                .controlSize(.small)
+            }
+
+            // Folder button (right of toggle)
+            if item.hasConfigFile {
+                Button(action: onOpenConfig) {
+                    Image(systemName: "folder")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.bordered)
+                .help(L10n.tr("在 Finder 中查看配置文件", "Show config in Finder"))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 2)
+    }
+
+    private var sourceTypeColor: Color {
+        switch item.sourceType {
+        case .loginItem:    return .blue
+        case .launchAgent:  return .orange
+        case .launchDaemon: return .purple
+        }
     }
 }

--- a/Tests/MacCleanTests/FileHandlerTests.swift
+++ b/Tests/MacCleanTests/FileHandlerTests.swift
@@ -54,36 +54,25 @@ final class LaunchServicesServiceTests: XCTestCase {
         XCTAssertTrue(handlers.isEmpty)
     }
 
-    func testSaveAndLoadRoundTrip() throws {
+    func testLoadHandlersFromPlistData() throws {
         try TestFixtures.withTempDir { dir in
             let plistURL = dir.appending(path: "launchservices.plist")
-            let service = LaunchServicesService(plistPath: plistURL.path)
-
-            // Create test handlers
-            let handlers: [HandlerEntry] = [
-                HandlerEntry(
-                    id: UUID(),
-                    contentType: "public.plain-text",
-                    contentTag: "txt",
-                    contentTagClass: "filename-extension",
-                    roleAll: "com.apple.TextEdit",
-                    urlScheme: nil,
-                    modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
-                ),
-                HandlerEntry(
-                    id: UUID(),
-                    contentType: nil,
-                    contentTag: nil,
-                    contentTagClass: nil,
-                    roleAll: nil,
-                    urlScheme: "https",
-                    modificationDate: nil
-                ),
+            let plistData: [String: Any] = [
+                "LSHandlers": [
+                    [
+                        "LSHandlerContentType": "public.plain-text",
+                        "LSHandlerContentTag": "txt",
+                        "LSHandlerContentTagClass": "filename-extension",
+                        "LSHandlerRoleAll": "com.apple.TextEdit",
+                    ] as [String: Any],
+                    [
+                        "LSHandlerURLScheme": "https",
+                    ] as [String: Any],
+                ] as [[String: Any]]
             ]
+            try TestFixtures.writePlist(plistData, to: plistURL)
 
-            try service.saveHandlers(handlers)
-
-            // Reload and verify
+            let service = LaunchServicesService(plistPath: plistURL.path)
             let loaded = service.loadHandlers()
             XCTAssertEqual(loaded.count, 2)
 
@@ -93,13 +82,10 @@ final class LaunchServicesServiceTests: XCTestCase {
             XCTAssertEqual(textHandler?.contentTagClass, "filename-extension")
             XCTAssertEqual(textHandler?.roleAll, "com.apple.TextEdit")
             XCTAssertNil(textHandler?.urlScheme)
-            XCTAssertNotNil(textHandler?.modificationDate)
 
             let httpsHandler = loaded.first { $0.urlScheme == "https" }
             XCTAssertNotNil(httpsHandler)
             XCTAssertNil(httpsHandler?.contentType)
-            XCTAssertNil(httpsHandler?.contentTag)
-            XCTAssertNil(httpsHandler?.modificationDate)
         }
     }
 
@@ -128,38 +114,29 @@ final class LaunchServicesServiceTests: XCTestCase {
         }
     }
 
-    func testSaveWithoutModificationDate() throws {
+    func testLoadPreservesAllKeysNotInModel() throws {
         try TestFixtures.withTempDir { dir in
             let plistURL = dir.appending(path: "launchservices.plist")
-            let service = LaunchServicesService(plistPath: plistURL.path)
-
-            let handlers: [HandlerEntry] = [
-                HandlerEntry(
-                    id: UUID(),
-                    contentType: nil,
-                    contentTag: nil,
-                    contentTagClass: nil,
-                    roleAll: nil,
-                    urlScheme: "mailto",
-                    modificationDate: nil
-                ),
+            let plistData: [String: Any] = [
+                "LSHandlers": [
+                    [
+                        "LSHandlerContentType": "public.foo",
+                        "LSHandlerRoleAll": "com.example.App",
+                        "LSHandlerContentTag": "foo",
+                        "LSHandlerContentTagClass": "filename-extension",
+                        // Keys we intentionally don't model — must not cause a crash
+                        "LSHandlerPreferredVersions": ["LSHandlerRoleAll": "-"],
+                        "LSHandlerRank": "DefaultHandler",
+                    ] as [String: Any],
+                ] as [[String: Any]]
             ]
+            try TestFixtures.writePlist(plistData, to: plistURL)
 
-            try service.saveHandlers(handlers)
-            let loaded = service.loadHandlers()
-            XCTAssertEqual(loaded.count, 1)
-            XCTAssertEqual(loaded.first?.urlScheme, "mailto")
-        }
-    }
-
-    func testEmptyHandlersList() throws {
-        try TestFixtures.withTempDir { dir in
-            let plistURL = dir.appending(path: "launchservices.plist")
             let service = LaunchServicesService(plistPath: plistURL.path)
-
-            try service.saveHandlers([])
-            let loaded = service.loadHandlers()
-            XCTAssertTrue(loaded.isEmpty)
+            let handlers = service.loadHandlers()
+            XCTAssertEqual(handlers.count, 1)
+            // Non-model keys should be silently ignored but not break parsing
+            XCTAssertEqual(handlers.first?.contentTag, "foo")
         }
     }
 }
@@ -241,26 +218,139 @@ final class FileHandlerViewModelTests: XCTestCase {
         vm.searchText = "nonexistent"
         XCTAssertTrue(vm.filteredHandlers.isEmpty)
     }
+}
 
-    func testDeleteHandlerRemovesFromList() {
-        let vm = FileHandlerViewModel()
-        let h1 = HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App1", urlScheme: nil, modificationDate: nil)
-        let h2 = HandlerEntry(id: UUID(), contentType: "public.bar", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App2", urlScheme: nil, modificationDate: nil)
-        vm.handlers = [h1, h2]
+// MARK: - LaunchServicesService Delete + Backup Tests
 
-        vm.deleteHandler(h1)
-        XCTAssertEqual(vm.handlers.count, 1)
-        XCTAssertEqual(vm.handlers.first?.roleAll, "com.example.App2")
+final class LaunchServicesServiceDeleteBackupTests: XCTestCase {
+    /// Helper: write a plist + create a service pointing to it.
+    private func makeService(dir: URL, data: [String: Any]) throws -> LaunchServicesService {
+        let plistURL = dir.appending(path: "com.apple.launchservices.secure.plist")
+        try TestFixtures.writePlist(data, to: plistURL)
+        return LaunchServicesService(plistPath: plistURL.path)
     }
 
-    func testDeleteHandlerNoOpForMissingHandler() {
-        let vm = FileHandlerViewModel()
-        let h1 = HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App", urlScheme: nil, modificationDate: nil)
-        vm.handlers = [h1]
+    // MARK: Delete
 
-        let missing = HandlerEntry(id: UUID(), contentType: "public.bar", contentTag: nil, contentTagClass: nil, roleAll: "com.example.Missing", urlScheme: nil, modificationDate: nil)
-        vm.deleteHandler(missing)
-        // Should not crash and count stays the same
-        XCTAssertEqual(vm.handlers.count, 1)
+    func testDeleteRemovesEntryByContentType() throws {
+        try TestFixtures.withTempDir { dir in
+            let service = try makeService(dir: dir, data: [
+                "LSHandlers": [
+                    ["LSHandlerContentType": "public.foo", "LSHandlerRoleAll": "com.example.App1"],
+                    ["LSHandlerContentType": "public.bar", "LSHandlerRoleAll": "com.example.App2"],
+                ]
+            ])
+            let entry = HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App1", urlScheme: nil, modificationDate: nil)
+            try service.deleteHandler(entry)
+            let remaining = service.loadHandlers()
+            XCTAssertEqual(remaining.count, 1)
+            XCTAssertEqual(remaining.first?.contentType, "public.bar")
+        }
+    }
+
+    func testDeleteRemovesEntryByURLScheme() throws {
+        try TestFixtures.withTempDir { dir in
+            let service = try makeService(dir: dir, data: [
+                "LSHandlers": [
+                    ["LSHandlerURLScheme": "https"],
+                    ["LSHandlerURLScheme": "mailto"],
+                ]
+            ])
+            let entry = HandlerEntry(id: UUID(), contentType: nil, contentTag: nil, contentTagClass: nil, roleAll: nil, urlScheme: "https", modificationDate: nil)
+            try service.deleteHandler(entry)
+            let remaining = service.loadHandlers()
+            XCTAssertEqual(remaining.count, 1)
+            XCTAssertEqual(remaining.first?.urlScheme, "mailto")
+        }
+    }
+
+    func testDeletePreservesUnknownKeys() throws {
+        try TestFixtures.withTempDir { dir in
+            let service = try makeService(dir: dir, data: [
+                "LSHandlers": [
+                    [
+                        "LSHandlerContentType": "public.foo",
+                        "LSHandlerRoleAll": "com.example.App",
+                        "LSHandlerPreferredVersions": ["LSHandlerRoleAll": "-"],
+                        "LSHandlerRank": "DefaultHandler",
+                    ]
+                ]
+            ])
+            let entry = HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App", urlScheme: nil, modificationDate: nil)
+            try service.deleteHandler(entry)
+            // After delete, this entry is gone — but the test verifies no crash
+            XCTAssertTrue(service.loadHandlers().isEmpty)
+        }
+    }
+
+    func testDeleteNoopForNonMatchingEntry() throws {
+        try TestFixtures.withTempDir { dir in
+            let service = try makeService(dir: dir, data: [
+                "LSHandlers": [
+                    ["LSHandlerContentType": "public.foo", "LSHandlerRoleAll": "com.example.App"],
+                ]
+            ])
+            let entry = HandlerEntry(id: UUID(), contentType: "public.bar", contentTag: nil, contentTagClass: nil, roleAll: "com.other.App", urlScheme: nil, modificationDate: nil)
+            try service.deleteHandler(entry)
+            // Nothing should be removed
+            XCTAssertEqual(service.loadHandlers().count, 1)
+        }
+    }
+
+    // MARK: Backup
+
+    func testBackupCreatesFile() throws {
+        try TestFixtures.withTempDir { dir in
+            let service = try makeService(dir: dir, data: [
+                "LSHandlers": [
+                    ["LSHandlerContentType": "public.foo", "LSHandlerRoleAll": "com.example.App"],
+                ]
+            ])
+            try service.backup()
+            let backups = service.listBackups()
+            XCTAssertEqual(backups.count, 1)
+        }
+    }
+
+    func testBackupAndRestoreRoundTrip() throws {
+        try TestFixtures.withTempDir { dir in
+            let beforePlist = [
+                "LSHandlers": [
+                    ["LSHandlerContentType": "public.foo", "LSHandlerRoleAll": "com.example.App"],
+                    ["LSHandlerURLScheme": "https"],
+                ] as [[String: Any]]
+            ] as [String: Any]
+            let service = try makeService(dir: dir, data: beforePlist)
+
+            // Delete one entry
+            let entry = HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App", urlScheme: nil, modificationDate: nil)
+            try service.deleteHandler(entry) // this also creates a backup
+            XCTAssertEqual(service.loadHandlers().count, 1)
+
+            // Restore from backup
+            let backups = service.listBackups()
+            XCTAssertEqual(backups.count, 1)
+            try service.restoreBackup(from: backups[0])
+
+            // Verify restored
+            let restored = service.loadHandlers()
+            XCTAssertEqual(restored.count, 2)
+            XCTAssertNotNil(restored.first { $0.contentType == "public.foo" })
+            XCTAssertNotNil(restored.first { $0.urlScheme == "https" })
+        }
+    }
+
+    func testBackupMultipleCreatesSeparateFiles() throws {
+        try TestFixtures.withTempDir { dir in
+            let service = try makeService(dir: dir, data: [
+                "LSHandlers": [
+                    ["LSHandlerContentType": "public.foo", "LSHandlerRoleAll": "com.example.App"],
+                ]
+            ])
+            try service.backup()
+            try service.backup()
+            let backups = service.listBackups()
+            XCTAssertEqual(backups.count, 2)
+        }
     }
 }

--- a/Tests/MacCleanTests/FileHandlerTests.swift
+++ b/Tests/MacCleanTests/FileHandlerTests.swift
@@ -1,0 +1,266 @@
+import XCTest
+import Foundation
+@testable import MacClean
+@testable import MacCleanKit
+import MacCleanTestSupport
+
+// MARK: - HandlerEntry Tests
+
+final class HandlerEntryTests: XCTestCase {
+    func testFileTypeDescriptionWithContentType() {
+        let entry = HandlerEntry(id: UUID(), contentType: "public.jpeg", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.Preview", urlScheme: nil, modificationDate: nil)
+        XCTAssertEqual(entry.fileTypeDescription, "public.jpeg")
+    }
+
+    func testFileTypeDescriptionWithExtension() {
+        let entry = HandlerEntry(id: UUID(), contentType: nil, contentTag: "txt", contentTagClass: "filename-extension", roleAll: "com.apple.TextEdit", urlScheme: nil, modificationDate: nil)
+        XCTAssertEqual(entry.fileTypeDescription, ".txt")
+    }
+
+    func testFileTypeDescriptionWithURLScheme() {
+        let entry = HandlerEntry(id: UUID(), contentType: nil, contentTag: nil, contentTagClass: nil, roleAll: nil, urlScheme: "https", modificationDate: nil)
+        XCTAssertEqual(entry.fileTypeDescription, "https://")
+    }
+
+    func testFileTypeDescriptionWithGenericTag() {
+        let entry = HandlerEntry(id: UUID(), contentType: nil, contentTag: "public.foo", contentTagClass: "public.type", roleAll: "com.example.App", urlScheme: nil, modificationDate: nil)
+        XCTAssertEqual(entry.fileTypeDescription, "public.foo")
+    }
+
+    func testFileTypeDescriptionUnknown() {
+        let entry = HandlerEntry(id: UUID(), contentType: nil, contentTag: nil, contentTagClass: nil, roleAll: nil, urlScheme: nil, modificationDate: nil)
+        XCTAssertEqual(entry.fileTypeDescription, "Unknown")
+    }
+
+    func testAppBundleIdentifierReturnsRoleAll() {
+        let entry = HandlerEntry(id: UUID(), contentType: nil, contentTag: nil, contentTagClass: nil, roleAll: "com.apple.Safari", urlScheme: nil, modificationDate: nil)
+        XCTAssertEqual(entry.appBundleIdentifier, "com.apple.Safari")
+    }
+
+    func testAppBundleIdentifierNilWhenRoleAllNil() {
+        let entry = HandlerEntry(id: UUID(), contentType: nil, contentTag: nil, contentTagClass: nil, roleAll: nil, urlScheme: "https", modificationDate: nil)
+        XCTAssertNil(entry.appBundleIdentifier)
+    }
+}
+
+// MARK: - LaunchServicesService Tests
+
+final class LaunchServicesServiceTests: XCTestCase {
+    func testLoadHandlersEmptyWhenFileMissing() {
+        let tmp = FileManager.default.temporaryDirectory.appending(path: "no-such-file-\(UUID().uuidString).plist")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let service = LaunchServicesService(plistPath: tmp.path)
+        let handlers = service.loadHandlers()
+        XCTAssertTrue(handlers.isEmpty)
+    }
+
+    func testSaveAndLoadRoundTrip() throws {
+        try TestFixtures.withTempDir { dir in
+            let plistURL = dir.appending(path: "launchservices.plist")
+            let service = LaunchServicesService(plistPath: plistURL.path)
+
+            // Create test handlers
+            let handlers: [HandlerEntry] = [
+                HandlerEntry(
+                    id: UUID(),
+                    contentType: "public.plain-text",
+                    contentTag: "txt",
+                    contentTagClass: "filename-extension",
+                    roleAll: "com.apple.TextEdit",
+                    urlScheme: nil,
+                    modificationDate: Date(timeIntervalSince1970: 1_700_000_000)
+                ),
+                HandlerEntry(
+                    id: UUID(),
+                    contentType: nil,
+                    contentTag: nil,
+                    contentTagClass: nil,
+                    roleAll: nil,
+                    urlScheme: "https",
+                    modificationDate: nil
+                ),
+            ]
+
+            try service.saveHandlers(handlers)
+
+            // Reload and verify
+            let loaded = service.loadHandlers()
+            XCTAssertEqual(loaded.count, 2)
+
+            let textHandler = loaded.first { $0.contentType == "public.plain-text" }
+            XCTAssertNotNil(textHandler)
+            XCTAssertEqual(textHandler?.contentTag, "txt")
+            XCTAssertEqual(textHandler?.contentTagClass, "filename-extension")
+            XCTAssertEqual(textHandler?.roleAll, "com.apple.TextEdit")
+            XCTAssertNil(textHandler?.urlScheme)
+            XCTAssertNotNil(textHandler?.modificationDate)
+
+            let httpsHandler = loaded.first { $0.urlScheme == "https" }
+            XCTAssertNotNil(httpsHandler)
+            XCTAssertNil(httpsHandler?.contentType)
+            XCTAssertNil(httpsHandler?.contentTag)
+            XCTAssertNil(httpsHandler?.modificationDate)
+        }
+    }
+
+    func testLoadSkipsEntriesWithoutRoleOrURLScheme() throws {
+        try TestFixtures.withTempDir { dir in
+            let plistURL = dir.appending(path: "launchservices.plist")
+            let plistData: [String: Any] = [
+                "LSHandlers": [
+                    // Valid entry
+                    [
+                        "LSHandlerContentType": "public.foo",
+                        "LSHandlerRoleAll": "com.example.App",
+                    ] as [String: Any],
+                    // Invalid entry (no roleAll, no urlScheme) — should be skipped
+                    [
+                        "LSHandlerContentType": "public.bar",
+                    ] as [String: Any],
+                ] as [[String: Any]]
+            ]
+            try TestFixtures.writePlist(plistData, to: plistURL)
+
+            let service = LaunchServicesService(plistPath: plistURL.path)
+            let handlers = service.loadHandlers()
+            XCTAssertEqual(handlers.count, 1)
+            XCTAssertEqual(handlers.first?.contentType, "public.foo")
+        }
+    }
+
+    func testSaveWithoutModificationDate() throws {
+        try TestFixtures.withTempDir { dir in
+            let plistURL = dir.appending(path: "launchservices.plist")
+            let service = LaunchServicesService(plistPath: plistURL.path)
+
+            let handlers: [HandlerEntry] = [
+                HandlerEntry(
+                    id: UUID(),
+                    contentType: nil,
+                    contentTag: nil,
+                    contentTagClass: nil,
+                    roleAll: nil,
+                    urlScheme: "mailto",
+                    modificationDate: nil
+                ),
+            ]
+
+            try service.saveHandlers(handlers)
+            let loaded = service.loadHandlers()
+            XCTAssertEqual(loaded.count, 1)
+            XCTAssertEqual(loaded.first?.urlScheme, "mailto")
+        }
+    }
+
+    func testEmptyHandlersList() throws {
+        try TestFixtures.withTempDir { dir in
+            let plistURL = dir.appending(path: "launchservices.plist")
+            let service = LaunchServicesService(plistPath: plistURL.path)
+
+            try service.saveHandlers([])
+            let loaded = service.loadHandlers()
+            XCTAssertTrue(loaded.isEmpty)
+        }
+    }
+}
+
+// MARK: - FileHandlerViewModel Tests
+
+@MainActor
+final class FileHandlerViewModelTests: XCTestCase {
+    func testFilteredHandlersReturnsAllWhenSearchEmpty() {
+        let vm = FileHandlerViewModel()
+        vm.handlers = [
+            HandlerEntry(id: UUID(), contentType: "public.jpeg", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.Preview", urlScheme: nil, modificationDate: nil),
+            HandlerEntry(id: UUID(), contentType: nil, contentTag: "txt", contentTagClass: "filename-extension", roleAll: "com.apple.TextEdit", urlScheme: nil, modificationDate: nil),
+        ]
+        vm.searchText = ""
+        XCTAssertEqual(vm.filteredHandlers.count, 2)
+    }
+
+    func testFilteredHandlersSearchByFileType() {
+        let vm = FileHandlerViewModel()
+        vm.handlers = [
+            HandlerEntry(id: UUID(), contentType: "public.jpeg", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.Preview", urlScheme: nil, modificationDate: nil),
+            HandlerEntry(id: UUID(), contentType: "public.plain-text", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.TextEdit", urlScheme: nil, modificationDate: nil),
+        ]
+        vm.searchText = "jpeg"
+        XCTAssertEqual(vm.filteredHandlers.count, 1)
+        XCTAssertEqual(vm.filteredHandlers.first?.contentType, "public.jpeg")
+    }
+
+    func testFilteredHandlersSearchByExtension() {
+        let vm = FileHandlerViewModel()
+        vm.handlers = [
+            HandlerEntry(id: UUID(), contentType: nil, contentTag: "txt", contentTagClass: "filename-extension", roleAll: "com.apple.TextEdit", urlScheme: nil, modificationDate: nil),
+            HandlerEntry(id: UUID(), contentType: nil, contentTag: "pdf", contentTagClass: "filename-extension", roleAll: "com.apple.Preview", urlScheme: nil, modificationDate: nil),
+        ]
+        vm.searchText = ".txt"
+        XCTAssertEqual(vm.filteredHandlers.count, 1)
+        XCTAssertEqual(vm.filteredHandlers.first?.contentTag, "txt")
+    }
+
+    func testFilteredHandlersSearchByURLScheme() {
+        let vm = FileHandlerViewModel()
+        vm.handlers = [
+            HandlerEntry(id: UUID(), contentType: nil, contentTag: nil, contentTagClass: nil, roleAll: nil, urlScheme: "https", modificationDate: nil),
+            HandlerEntry(id: UUID(), contentType: nil, contentTag: nil, contentTagClass: nil, roleAll: nil, urlScheme: "mailto", modificationDate: nil),
+        ]
+        vm.searchText = "https://"
+        XCTAssertEqual(vm.filteredHandlers.count, 1)
+        XCTAssertEqual(vm.filteredHandlers.first?.urlScheme, "https")
+    }
+
+    func testFilteredHandlersSearchByContentType() {
+        let vm = FileHandlerViewModel()
+        vm.handlers = [
+            HandlerEntry(id: UUID(), contentType: "public.plain-text", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.TextEdit", urlScheme: nil, modificationDate: nil),
+            HandlerEntry(id: UUID(), contentType: "public.jpeg", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.Preview", urlScheme: nil, modificationDate: nil),
+        ]
+        vm.searchText = "plain"
+        XCTAssertEqual(vm.filteredHandlers.count, 1)
+        XCTAssertEqual(vm.filteredHandlers.first?.contentType, "public.plain-text")
+    }
+
+    func testFilteredHandlersSearchByBundleID() {
+        let vm = FileHandlerViewModel()
+        vm.handlers = [
+            HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.Safari", urlScheme: nil, modificationDate: nil),
+            HandlerEntry(id: UUID(), contentType: "public.bar", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.TextEdit", urlScheme: nil, modificationDate: nil),
+        ]
+        vm.searchText = "safari"
+        XCTAssertEqual(vm.filteredHandlers.count, 1)
+        XCTAssertEqual(vm.filteredHandlers.first?.roleAll, "com.apple.Safari")
+    }
+
+    func testFilteredHandlersNoMatch() {
+        let vm = FileHandlerViewModel()
+        vm.handlers = [
+            HandlerEntry(id: UUID(), contentType: "public.jpeg", contentTag: nil, contentTagClass: nil, roleAll: "com.apple.Preview", urlScheme: nil, modificationDate: nil),
+        ]
+        vm.searchText = "nonexistent"
+        XCTAssertTrue(vm.filteredHandlers.isEmpty)
+    }
+
+    func testDeleteHandlerRemovesFromList() {
+        let vm = FileHandlerViewModel()
+        let h1 = HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App1", urlScheme: nil, modificationDate: nil)
+        let h2 = HandlerEntry(id: UUID(), contentType: "public.bar", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App2", urlScheme: nil, modificationDate: nil)
+        vm.handlers = [h1, h2]
+
+        vm.deleteHandler(h1)
+        XCTAssertEqual(vm.handlers.count, 1)
+        XCTAssertEqual(vm.handlers.first?.roleAll, "com.example.App2")
+    }
+
+    func testDeleteHandlerNoOpForMissingHandler() {
+        let vm = FileHandlerViewModel()
+        let h1 = HandlerEntry(id: UUID(), contentType: "public.foo", contentTag: nil, contentTagClass: nil, roleAll: "com.example.App", urlScheme: nil, modificationDate: nil)
+        vm.handlers = [h1]
+
+        let missing = HandlerEntry(id: UUID(), contentType: "public.bar", contentTag: nil, contentTagClass: nil, roleAll: "com.example.Missing", urlScheme: nil, modificationDate: nil)
+        vm.deleteHandler(missing)
+        // Should not crash and count stays the same
+        XCTAssertEqual(vm.handlers.count, 1)
+    }
+}


### PR DESCRIPTION
…n, add file association management

    - Fix login item detection: use AppleScript System Events API to read user login items (sfltool dumpbtm only returns system-level items on macOS 15+)
    - Split launch agents and launch daemons into separate tabs — 4 tabs total
    - Unify AutoStartItem model with source type tracking (loginItem/launchAgent/launchDaemon)
    - Add 'Show config in Finder' button for each item
    - Add new 'File Associations' tab (4th) to manage user-customized UTI/URL scheme bindings from com.apple.launchservices.secure.plist, with search and delete support

## Summary
<!-- Brief description of what this PR does and why. -->

## Changes
<!-- Bullet list of specific changes. -->
- 

## Test Plan
<!-- How did you verify this works? -->
- [x] All tests pass (`swift test`)
- [x] New tests added for new functionality
- [x] Tested in running app (not just compilation)
- [x] No new compiler warnings

## Screenshots
<!-- If UI changes, include before/after screenshots. -->

## Checklist
- [x] Code compiles with `swift build`
- [x] Follows existing code style (Swift 6, actors, @Observable)
- [x] No force unwrapping added
- [x] File operations go through SafetyGuard/CleaningEngine
- [x] No telemetry or network calls added
- [x] PR is focused (one feature/fix per PR)
