### PR TITLE
Complete uninstall: fix cask zap + add uninstaller script and docs (#95)

### DIFF
--- a/Casks/mac-sai.rb
+++ b/Casks/mac-sai.rb
@@ -24,8 +24,10 @@ cask "mac-sai" do
   zap trash: [
     "~/Library/Application Support/MacClean",
     "~/Library/Caches/com.macclean.app",
+    "~/Library/HTTPStorages/com.macclean.app",
     "~/Library/Logs/MacClean",
     "~/Library/Preferences/com.macclean.app.plist",
+    "~/Library/Preferences/com.macclean.shared.plist",
     "~/Library/Saved Application State/com.macclean.app.savedState",
   ]
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ Some modules (Mail Attachments, Privacy, Malware) need Full Disk Access to scan 
 2. Click **+** and add **Mac Sai.app** from Applications
 3. Restart Mac Sai
 
+### Uninstalling
+
+If you installed with Homebrew, remove the app and all of its support files in one command:
+
+```bash
+brew uninstall --zap --cask mac-sai
+```
+
+For a DMG or manual install, run the uninstaller (it also handles a Homebrew install):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/iliyami/MacSai/main/scripts/uninstall.sh | bash
+```
+
+Both remove Mac Sai plus its preferences, caches, logs, and database under `~/Library`. If a leftover entry remains under **System Settings → General → Login Items**, remove it there; macOS clears it once the app is gone.
+
 ## Signed & notarized: why you can trust it
 
 Mac Sai is code-signed with an Apple **Developer ID** and **notarized by Apple**. That matters more for a cleaning app than for almost anything else you install, because you are about to give it deep access to your files. You deserve to know that what runs on your Mac is genuinely ours and has not been tampered with.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -215,6 +215,22 @@ bash scripts/build-dmg.sh      # 构建本地 DMG（未签名）
 2. 点击 **+**，从“应用程序”中添加 **Mac Sai.app**
 3. 重新启动 Mac Sai
 
+### 卸载
+
+如果你是通过 Homebrew 安装的，一条命令即可删除应用及其所有支持文件：
+
+```bash
+brew uninstall --zap --cask mac-sai
+```
+
+如果是 DMG 或手动安装，运行卸载脚本（它同样能处理 Homebrew 安装）：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/iliyami/MacSai/main/scripts/uninstall.sh | bash
+```
+
+两种方式都会删除 Mac Sai 以及它在 `~/Library` 下的偏好设置、缓存、日志和数据库。如果 **系统设置 → 通用 → 登录项** 中仍有残留条目，请在那里手动删除；应用删除后 macOS 会自动清理它。
+
 ## 已签名并公证：为什么你可以信任它
 
 Mac Sai 使用 Apple **Developer ID** 进行代码签名，并经 **Apple 公证**。对于一款清理类应用而言，这一点比几乎任何其他你安装的软件都更重要，因为你即将赋予它对文件的深度访问权限。你理应确信，运行在你 Mac 上的东西确实出自我们之手，且未被篡改。

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Completely remove Mac Sai and its support files.
+# Usage: curl -fsSL https://raw.githubusercontent.com/iliyami/MacSai/main/scripts/uninstall.sh | bash
+#
+# Homebrew users can instead run:  brew uninstall --zap --cask mac-sai
+# (the --zap flag removes the same support files via the cask's zap stanza).
+
+set -euo pipefail
+
+APP_NAME="Mac Sai.app"
+INSTALL_DIR="/Applications"
+
+cyan() { printf "\033[36m%s\033[0m\n" "$1"; }
+green() { printf "\033[32m%s\033[0m\n" "$1"; }
+red() { printf "\033[31m%s\033[0m\n" "$1"; }
+
+# Guard: HOME must be set so the explicit paths below never expand to "/...".
+if [ -z "${HOME:-}" ]; then
+  red "HOME is not set; aborting to avoid removing unintended paths."
+  exit 1
+fi
+
+# Exact, explicit paths only (no globs, no wildcards) so this can never delete
+# more than Mac Sai's own files.
+SUPPORT_PATHS=(
+  "$HOME/Library/Application Support/MacClean"
+  "$HOME/Library/Caches/com.macclean.app"
+  "$HOME/Library/HTTPStorages/com.macclean.app"
+  "$HOME/Library/Logs/MacClean"
+  "$HOME/Library/Preferences/com.macclean.app.plist"
+  "$HOME/Library/Preferences/com.macclean.shared.plist"
+  "$HOME/Library/Saved Application State/com.macclean.app.savedState"
+)
+
+cyan "Quitting Mac Sai if it is running..."
+osascript -e 'tell application "Mac Sai" to quit' >/dev/null 2>&1 || true
+# The menu-bar helper is a separate process.
+pkill -f "MacCleanMenu" >/dev/null 2>&1 || true
+
+# Prefer Homebrew's own uninstall when the cask is installed, so brew's receipt
+# stays consistent. --zap removes the support files too, so we're done after it.
+if command -v brew >/dev/null 2>&1 && brew list --cask mac-sai >/dev/null 2>&1; then
+  cyan "Removing the Homebrew cask (with --zap to clear support files)..."
+  brew uninstall --zap --cask mac-sai
+  green "✓ Mac Sai and its support files were removed via Homebrew."
+  exit 0
+fi
+
+cyan "Removing $INSTALL_DIR/$APP_NAME..."
+rm -rf "$INSTALL_DIR/$APP_NAME"
+
+cyan "Removing support files..."
+for path in "${SUPPORT_PATHS[@]}"; do
+  if [ -e "$path" ]; then
+    rm -rf "$path"
+    echo "  removed $path"
+  fi
+done
+
+# Clear any cached preferences held by cfprefsd so they don't get rewritten.
+defaults delete com.macclean.app >/dev/null 2>&1 || true
+defaults delete com.macclean.shared >/dev/null 2>&1 || true
+
+green ""
+green "✓ Mac Sai has been uninstalled."
+echo ""
+echo "If Mac Sai still appears under System Settings → General → Login Items,"
+echo "remove the leftover entry there; macOS clears it once the app is gone."


### PR DESCRIPTION
Fixes #95.

Users reported leftover files after removing Mac Sai. Root cause: the cask's `zap` stanza was incomplete, so even `brew uninstall --zap` left some files behind, and there was no documented uninstall path for DMG/manual installs.

## Changes
- **Cask `zap`**: add `~/Library/Preferences/com.macclean.shared.plist` (the shared-state suite written by `SharedAppState`, the main leftover users saw) and `~/Library/HTTPStorages/com.macclean.app`. Now `brew uninstall --zap --cask mac-sai` removes everything.
- **`scripts/uninstall.sh`** for DMG/manual installs: explicit absolute paths only (no globs/wildcards), guards `$HOME`, quits the app + menu helper, prefers `brew uninstall --zap` when the cask is present, and clears `cfprefsd` caches.
- **README** (English + 简体中文): a new "Uninstalling" section.

## Verified
- `bash -n scripts/uninstall.sh` OK
- `brew style Casks/mac-sai.rb` clean on the changed lines (the pre-existing `desc` lint is unrelated and already corrected in the official homebrew-cask submission)
- No binary change, so no version bump.