### PR TITLE
fix(launchservices): cap backups at 20 and make restore atomic

### DIFF
--- a/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
+++ b/Sources/MacClean/Modules/Optimization/LaunchServicesService.swift
@@ -92,7 +92,10 @@ public final class LaunchServicesService: @unchecked Sendable {
 
     // MARK: - Backup / Restore
 
-    /// Snapshot the current plist to the backup directory.
+    private static let maxBackups = 20
+
+    /// Snapshot the current plist to the backup directory, then trim to
+    /// `maxBackups` so the folder doesn't grow unbounded.
     public func backup() throws {
         let src = URL(fileURLWithPath: plistPath)
         guard FileManager.default.fileExists(atPath: plistPath) else { return }
@@ -112,6 +115,17 @@ public final class LaunchServicesService: @unchecked Sendable {
         } catch {
             throw LaunchServicesError.backupFailed(error)
         }
+        // Prune old backups beyond the cap.
+        trimBackups()
+    }
+
+    /// Remove backups beyond `maxBackups`, keeping the newest ones.
+    private func trimBackups() {
+        let all = listBackups()
+        guard all.count > Self.maxBackups else { return }
+        for stale in all[Self.maxBackups...] {
+            try? FileManager.default.removeItem(at: stale)
+        }
     }
 
     /// List available backups newest-first (sorted by filename timestamp).
@@ -125,16 +139,19 @@ public final class LaunchServicesService: @unchecked Sendable {
             .sorted { $0.lastPathComponent > $1.lastPathComponent }
     }
 
-    /// Restore a specific backup to the live plist path, replacing the current.
+    /// Restore a backup to the live plist path using an atomic swap so a
+    /// mid-failure can never leave the user with neither file.
     public func restoreBackup(from url: URL) throws {
         let dst = URL(fileURLWithPath: plistPath)
+        let tmpDir = dst.deletingLastPathComponent()
+        let tmpURL = tmpDir.appending(path: ".launchservices-restore-tmp.plist")
+        // Clean any stale temp from a previous crash.
+        try? FileManager.default.removeItem(at: tmpURL)
         do {
-            // Remove current, then copy backup in its place.
-            if FileManager.default.fileExists(atPath: plistPath) {
-                try FileManager.default.removeItem(at: dst)
-            }
-            try FileManager.default.copyItem(at: url, to: dst)
+            try FileManager.default.copyItem(at: url, to: tmpURL)
+            _ = try FileManager.default.replaceItemAt(dst, withItemAt: tmpURL)
         } catch {
+            try? FileManager.default.removeItem(at: tmpURL)
             throw LaunchServicesError.restoreFailed(error)
         }
     }


### PR DESCRIPTION
According to previous PR's review ([previous PR](https://github.com/iliyami/MacSai/pull/99#issuecomment-4821673308)), here is the additional fix: 

- Prune old backups beyond the 20 most recent after each new backup to prevent unbounded growth in the backup folder
- Make restoreBackup atomic: copy backup to a temp file in the same directory first, then use FileManager.replaceItemAt for an atomic swap — a mid-failure can no longer leave the user with neither file

## Test Plan
<!-- How did you verify this works? -->
- [x] All tests pass (`swift test`)
- [ ] New tests added for new functionality
- [x] Tested in running app (not just compilation)
- [x] No new compiler warnings

## Screenshots
<!-- If UI changes, include before/after screenshots. -->

## Checklist
- [x] Code compiles with `swift build`
- [x] Follows existing code style (Swift 6, actors, @Observable)
- [x] No force unwrapping added
- [x] File operations go through SafetyGuard/CleaningEngine
- [x] No telemetry or network calls added
- [x] PR is focused (one feature/fix per PR)
