### PR TITLE
Enable Buy Me a Coffee sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,10 +1,10 @@
 # GitHub Sponsors / funding sources for Mac Sai.
 # These surface a "Sponsor" button on the repo page.
-#
-# Uncomment lines as you set up each platform.
 
+buy_me_a_coffee: iliyami
+
+# Other platforms (uncomment as you set them up):
 # github: [iliyami]
 # open_collective: macclean
 # ko_fi: iliyami
 # patreon: iliyami
-# custom: ["https://buymeacoffee.com/iliyami"]


### PR DESCRIPTION
Activates the GitHub "Sponsor" button using the native Buy Me a Coffee funding key.

- `buy_me_a_coffee: iliyami` (assumes https://buymeacoffee.com/iliyami — please confirm the handle before merging)
- Other platforms kept commented for later.

The Sponsor button appears once this is on the default branch, so merging is what makes it live. No code change, no version bump.