### PR TITLE
docs: switch install to the official Homebrew cask (no tap)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,7 +204,7 @@ jobs:
           ### Install via Homebrew
 
           \`\`\`
-          brew tap iliyami/macsai && brew install --cask mac-sai
+          brew install --cask mac-sai
           \`\`\`
 
           ### Or download directly

--- a/README.md
+++ b/README.md
@@ -373,11 +373,13 @@ Inspired by the open-source Mac utility community:
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#iliyami/MacSai&Date">
-    <img src="https://img.shields.io/github/stars/iliyami/MacSai?style=for-the-badge&logo=github&label=Stars&color=gold" alt="GitHub stars" />
+  <a href="https://www.star-history.com/?repos=iliyami%2FMacSai&type=date&legend=top-left">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&theme=dark&legend=top-left&sealed_token=U-awhgge-qJwqcwRMpeYAooRYIriMPXuNrQErHZuAQsbmKYoo3D7oum-5zvqFjZlP77FXRFg56nh-1Ie9oWSBAPeS7-NUe70kSI-3XJ_Ce97vHA0OQcqEKhE0STA4FhfJ-bkteG7lb2xAVJWcLPtIJalJjJuhE2nrgA4rrcQbs6cJPk2-sbuJw76SARx" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left&sealed_token=U-awhgge-qJwqcwRMpeYAooRYIriMPXuNrQErHZuAQsbmKYoo3D7oum-5zvqFjZlP77FXRFg56nh-1Ie9oWSBAPeS7-NUe70kSI-3XJ_Ce97vHA0OQcqEKhE0STA4FhfJ-bkteG7lb2xAVJWcLPtIJalJjJuhE2nrgA4rrcQbs6cJPk2-sbuJw76SARx" />
+      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left&sealed_token=U-awhgge-qJwqcwRMpeYAooRYIriMPXuNrQErHZuAQsbmKYoo3D7oum-5zvqFjZlP77FXRFg56nh-1Ie9oWSBAPeS7-NUe70kSI-3XJ_Ce97vHA0OQcqEKhE0STA4FhfJ-bkteG7lb2xAVJWcLPtIJalJjJuhE2nrgA4rrcQbs6cJPk2-sbuJw76SARx" />
+    </picture>
   </a>
-  <br>
-  <a href="https://star-history.com/#iliyami/MacSai&Date">View the interactive star history chart</a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -373,13 +373,11 @@ Inspired by the open-source Mac utility community:
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/?type=date&repos=iliyami%2FMacSai">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left" />
-      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left" />
-    </picture>
+  <a href="https://star-history.com/#iliyami/MacSai&Date">
+    <img src="https://img.shields.io/github/stars/iliyami/MacSai?style=for-the-badge&logo=github&label=Stars&color=gold" alt="GitHub stars" />
   </a>
+  <br>
+  <a href="https://star-history.com/#iliyami/MacSai&Date">View the interactive star history chart</a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 > Installed it through Homebrew under the old name? Switch with:
 > ```bash
 > brew uninstall --cask mac-clean && brew untap iliyami/macclean
-> brew tap iliyami/macsai && brew install --cask mac-sai
+> brew install --cask mac-sai
 > ```
 
 <p align="center">
@@ -43,7 +43,7 @@
 </p>
 
 ```bash
-brew tap iliyami/macsai && brew install --cask mac-sai
+brew install --cask mac-sai
 ```
 
 <p align="center">
@@ -179,11 +179,15 @@ Mac Sai is designed to **never cause data loss**:
 
 ### Homebrew (recommended — one command, no warnings)
 
+Mac Sai is in the official Homebrew cask repository, so no tap is needed:
+
 ```bash
-brew tap iliyami/macsai && brew install --cask mac-sai
+brew install --cask mac-sai
 ```
 
 Mac Sai is notarized by Apple, so it launches from Spotlight or Applications with no warnings, no right-clicks, and no commands.
+
+> Installed via the old `iliyami/macsai` tap? You can drop it now that Mac Sai is in the official cask: `brew untap iliyami/macsai` (your installed app and future `brew upgrade` are unaffected).
 
 ### One-line installer
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -373,11 +373,13 @@ Mac Sai 认真对待安全：
 ## Star 历史
 
 <p align="center">
-  <a href="https://star-history.com/#iliyami/MacSai&Date">
-    <img src="https://img.shields.io/github/stars/iliyami/MacSai?style=for-the-badge&logo=github&label=Stars&color=gold" alt="GitHub stars" />
+  <a href="https://www.star-history.com/?repos=iliyami%2FMacSai&type=date&legend=top-left">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&theme=dark&legend=top-left&sealed_token=U-awhgge-qJwqcwRMpeYAooRYIriMPXuNrQErHZuAQsbmKYoo3D7oum-5zvqFjZlP77FXRFg56nh-1Ie9oWSBAPeS7-NUe70kSI-3XJ_Ce97vHA0OQcqEKhE0STA4FhfJ-bkteG7lb2xAVJWcLPtIJalJjJuhE2nrgA4rrcQbs6cJPk2-sbuJw76SARx" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left&sealed_token=U-awhgge-qJwqcwRMpeYAooRYIriMPXuNrQErHZuAQsbmKYoo3D7oum-5zvqFjZlP77FXRFg56nh-1Ie9oWSBAPeS7-NUe70kSI-3XJ_Ce97vHA0OQcqEKhE0STA4FhfJ-bkteG7lb2xAVJWcLPtIJalJjJuhE2nrgA4rrcQbs6cJPk2-sbuJw76SARx" />
+      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left&sealed_token=U-awhgge-qJwqcwRMpeYAooRYIriMPXuNrQErHZuAQsbmKYoo3D7oum-5zvqFjZlP77FXRFg56nh-1Ie9oWSBAPeS7-NUe70kSI-3XJ_Ce97vHA0OQcqEKhE0STA4FhfJ-bkteG7lb2xAVJWcLPtIJalJjJuhE2nrgA4rrcQbs6cJPk2-sbuJw76SARx" />
+    </picture>
   </a>
-  <br>
-  <a href="https://star-history.com/#iliyami/MacSai&Date">查看交互式 Star 历史图表</a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@
 > 之前通过 Homebrew 以旧名安装的？用以下命令切换：
 > ```bash
 > brew uninstall --cask mac-clean && brew untap iliyami/macclean
-> brew tap iliyami/macsai && brew install --cask mac-sai
+> brew install --cask mac-sai
 > ```
 
 <p align="center">
@@ -43,7 +43,7 @@
 </p>
 
 ```bash
-brew tap iliyami/macsai && brew install --cask mac-sai
+brew install --cask mac-sai
 ```
 
 <p align="center">
@@ -179,11 +179,15 @@ Mac Sai 的设计目标是**绝不造成数据丢失**：
 
 ### Homebrew（推荐，一条命令，无任何警告）
 
+Mac Sai 已收录进官方 Homebrew cask 仓库，无需 tap：
+
 ```bash
-brew tap iliyami/macsai && brew install --cask mac-sai
+brew install --cask mac-sai
 ```
 
 Mac Sai 已经过 Apple 公证，可从聚焦或“应用程序”直接启动，没有警告、无需右键、也无需命令行。
+
+> 之前通过旧的 `iliyami/macsai` tap 安装的？现在 Mac Sai 已进入官方 cask，可以移除它：`brew untap iliyami/macsai`（不影响已安装的应用和后续的 `brew upgrade`）。
 
 ### 一行安装脚本
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -373,13 +373,11 @@ Mac Sai 认真对待安全：
 ## Star 历史
 
 <p align="center">
-  <a href="https://www.star-history.com/?type=date&repos=iliyami%2FMacSai">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left" />
-      <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=iliyami/MacSai&type=date&legend=top-left" />
-    </picture>
+  <a href="https://star-history.com/#iliyami/MacSai&Date">
+    <img src="https://img.shields.io/github/stars/iliyami/MacSai?style=for-the-badge&logo=github&label=Stars&color=gold" alt="GitHub stars" />
   </a>
+  <br>
+  <a href="https://star-history.com/#iliyami/MacSai&Date">查看交互式 Star 历史图表</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Mac Sai is now in the official Homebrew cask repository ([Homebrew/homebrew-cask#270072](https://github.com/Homebrew/homebrew-cask/pull/270072), merged), so installation no longer needs a tap.

## Changes
- README.md and README.zh-CN.md: install command is now `brew install --cask mac-sai` (was `brew tap iliyami/macsai && ...`), in all spots including the rename notice.
- Added a short note for existing users of the old `iliyami/macsai` tap that they can `brew untap iliyami/macsai` (installed app and future upgrades unaffected).
- release.yml release-notes template updated to the tap-free command.

No code change, no version bump.