### PR TITLE
Space Lens: color by file type like Space Sniffer, add legend, responsive canvas

### DIFF
--- a/Sources/MacClean/Core/Scanner/FileTreeScanner.swift
+++ b/Sources/MacClean/Core/Scanner/FileTreeScanner.swift
@@ -87,12 +87,14 @@ public actor FileTreeScanner {
             guard let values = try? fileURL.resourceValues(forKeys: keys) else { continue }
             let size = UInt64(values.totalFileAllocatedSize ?? values.fileAllocatedSize ?? values.fileSize ?? 0)
             let isDir = values.isDirectory ?? false
+            let ext = values.name?.components(separatedBy: ".").last?.lowercased() ?? fileURL.pathExtension.lowercased()
 
             let node = FileNode(
                 url: fileURL,
                 name: values.name ?? fileURL.lastPathComponent,
                 size: isDir ? 0 : size,
-                isDirectory: isDir
+                isDirectory: isDir,
+                fileExtension: ext
             )
 
             let parentPath = key(fileURL.deletingLastPathComponent())
@@ -132,14 +134,16 @@ public final class FileNode: @unchecked Sendable {
     public let name: String
     public private(set) var size: UInt64
     public let isDirectory: Bool
+    public let fileExtension: String
     public private(set) var children: [FileNode] = []
     public private(set) var totalSize: UInt64 = 0
 
-    public init(url: URL, name: String, size: UInt64 = 0, isDirectory: Bool = true) {
+    public init(url: URL, name: String, size: UInt64 = 0, isDirectory: Bool = true, fileExtension: String = "") {
         self.url = url
         self.name = name
         self.size = size
         self.isDirectory = isDirectory
+        self.fileExtension = fileExtension
         self.totalSize = size
     }
 

--- a/Sources/MacClean/Views/Files/SpaceLensView.swift
+++ b/Sources/MacClean/Views/Files/SpaceLensView.swift
@@ -11,29 +11,52 @@ struct SpaceLensView: View {
 
     private let scanner = FileTreeScanner()
 
+    private var totalFormattedSize: String {
+        rootNode?.formattedTotalSize ?? ""
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(L10n.tr("空间透视", "Space Lens"))
-                        .font(.system(size: 22, weight: .bold))
-                        .foregroundStyle(.primary)
+            header
+            breadcrumbBar
+            content
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(L10n.tr("空间透视", "Space Lens"))
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(.primary)
+                HStack(spacing: 6) {
                     Text(L10n.tr("可视化磁盘空间使用情况", "Visualize disk space usage"))
                         .font(.system(size: 12))
                         .foregroundStyle(.primary.opacity(0.6))
-                }
-                Spacer()
-                if !isScanning {
-                    Button(L10n.tr("扫描", "Scan")) { startScan() }
-                        .buttonStyle(SuperEllipseButtonStyle(
-                            gradient: ModuleTheme.files.buttonGradient,
-                            size: CGSize(width: 90, height: 34)
-                        ))
+                    if !totalFormattedSize.isEmpty {
+                        Text("·")
+                            .foregroundStyle(.primary.opacity(0.3))
+                        Text(totalFormattedSize)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.primary.opacity(0.7))
+                    }
                 }
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 16)
+            Spacer()
+            if !isScanning {
+                Button(L10n.tr("扫描", "Scan")) { startScan() }
+                    .buttonStyle(SuperEllipseButtonStyle(
+                        gradient: ModuleTheme.files.buttonGradient,
+                        size: CGSize(width: 90, height: 34)
+                    ))
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 16)
+    }
 
+    private var breadcrumbBar: some View {
+        Group {
             if nav.breadcrumbs.count > 1 {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 4) {
@@ -66,48 +89,81 @@ struct SpaceLensView: View {
                     .padding(.bottom, 8)
                 }
             }
-
-            if isScanning {
-                Spacer()
-                ScanProgressRing(progress: 0.5, phase: L10n.tr("正在扫描磁盘...", "Scanning disk..."), theme: .files)
-                Button(L10n.tr("取消", "Cancel")) {
-                    scanTask?.cancel()
-                    isScanning = false
-                }
-                .buttonStyle(.bordered)
-                .tint(.primary)
-                .controlSize(.large)
-                Spacer()
-            } else if !treemapRects.isEmpty {
-                GeometryReader { geo in
-                    ZStack {
-                        ForEach(treemapRects) { item in
-                            treemapCell(item, containerSize: geo.size)
-                        }
-                    }
-                    .padding(20)
-                }
-            } else {
-                Spacer()
-                VStack(spacing: 14) {
-                    Image(systemName: "chart.pie")
-                        .font(.system(size: 44))
-                        .foregroundStyle(.primary.opacity(0.4))
-                    Text(L10n.tr("点击“扫描”以可视化磁盘使用情况", "Click Scan to visualize disk usage"))
-                        .font(.system(size: 14))
-                        .foregroundStyle(.primary.opacity(0.55))
-                }
-                Spacer()
-            }
         }
     }
 
-    private func treemapCell(_ item: TreemapRect, containerSize: CGSize) -> some View {
-        let colors: [Color] = [.blue, .green, .orange, .purple, .pink, .teal, .indigo, .mint]
-        let colorIndex = abs(item.node.name.hashValue) % colors.count
+    @ViewBuilder
+    private var content: some View {
+        if isScanning {
+            Spacer()
+            ScanProgressRing(progress: 0.5, phase: L10n.tr("正在扫描磁盘...", "Scanning disk..."), theme: .files)
+            Button(L10n.tr("取消", "Cancel")) {
+                scanTask?.cancel()
+                isScanning = false
+            }
+            .buttonStyle(.bordered)
+            .tint(.primary)
+            .controlSize(.large)
+            Spacer()
+        } else if !treemapRects.isEmpty {
+            GeometryReader { geo in
+                VStack(spacing: 0) {
+                    treemapCanvas(containerSize: geo.size)
+                    legend
+                }
+            }
+        } else {
+            Spacer()
+            VStack(spacing: 14) {
+                Image(systemName: "chart.pie")
+                    .font(.system(size: 44))
+                    .foregroundStyle(.primary.opacity(0.4))
+                Text(L10n.tr("点击“扫描”以可视化磁盘使用情况", "Click Scan to visualize disk usage"))
+                    .font(.system(size: 14))
+                    .foregroundStyle(.primary.opacity(0.55))
+            }
+            Spacer()
+        }
+    }
+
+    private func treemapCanvas(containerSize: CGSize) -> some View {
+        let canvasWidth = max(containerSize.width - 40, 100)
+        let canvasHeight = max(containerSize.height - 80, 200)
+        let bounds = CGRect(x: 0, y: 0, width: canvasWidth, height: canvasHeight)
+
+        let rects = SquarifiedTreemap.layout(nodes: treemapRects.map(\.node), in: bounds)
+
+        return ZStack {
+            ForEach(rects) { item in
+                treemapCell(item)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 10)
+    }
+
+    private func color(for category: FileTypeCategory) -> Color {
+        switch category {
+        case .folders: .blue
+        case .documents: .orange
+        case .images: .green
+        case .video: .purple
+        case .audio: .pink
+        case .archives: .yellow
+        case .code: .cyan
+        case .diskImages: .teal
+        case .applications: .indigo
+        case .system: .gray
+        case .other: Color(white: 0.6)
+        }
+    }
+
+    private func treemapCell(_ item: TreemapRect) -> some View {
+        let cat = item.node.fileTypeCategory
+        let cellColor = color(for: cat)
 
         return RoundedRectangle(cornerRadius: 4)
-            .fill(colors[colorIndex].opacity(0.7))
+            .fill(cellColor.opacity(0.7))
             .frame(width: max(item.rect.width - 2, 0), height: max(item.rect.height - 2, 0))
             .overlay {
                 if item.rect.width > 60 && item.rect.height > 30 {
@@ -130,12 +186,29 @@ struct SpaceLensView: View {
                     startScan()
                 }
             }
+            .help(item.node.name + " (" + item.node.fileTypeCategory.label + ")")
+    }
+
+    private var legend: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 12) {
+                ForEach(FileTypeCategory.allCases, id: \.self) { cat in
+                    HStack(spacing: 4) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(color(for: cat))
+                            .frame(width: 10, height: 10)
+                        Text(cat.label)
+                            .font(.system(size: 10))
+                            .foregroundStyle(.primary.opacity(0.7))
+                    }
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 8)
+        }
     }
 
     private func startScan() {
-        // Cancel any in-flight scan first. Breadcrumb taps can fire while a
-        // scan is running; without this the old task would keep running and
-        // race the new one to overwrite rootNode/treemapRects/isScanning.
         scanTask?.cancel()
         isScanning = true
         scanTask = Task {
@@ -152,7 +225,7 @@ struct SpaceLensView: View {
                         size: child.totalSize,
                         url: child.url,
                         isDirectory: child.isDirectory,
-                        children: []
+                        fileExtension: child.fileExtension
                     )
                 }
 

--- a/Sources/MacCleanKit/SquarifiedTreemap.swift
+++ b/Sources/MacCleanKit/SquarifiedTreemap.swift
@@ -1,12 +1,68 @@
 import Foundation
 import CoreGraphics
 
+/// File type category for treemap color coding (inspired by Space Sniffer).
+public enum FileTypeCategory: String, Sendable, CaseIterable {
+    case folders
+    case documents
+    case images
+    case video
+    case audio
+    case archives
+    case code
+    case diskImages
+    case applications
+    case system
+    case other
+
+    public var label: String {
+        switch self {
+        case .folders: "Folders"
+        case .documents: "Documents"
+        case .images: "Images"
+        case .video: "Video"
+        case .audio: "Audio"
+        case .archives: "Archives"
+        case .code: "Code"
+        case .diskImages: "Disk Images"
+        case .applications: "Applications"
+        case .system: "System"
+        case .other: "Other"
+        }
+    }
+
+    public static func category(forFileExtension ext: String, isDirectory: Bool) -> FileTypeCategory {
+        if isDirectory { return .folders }
+        let lower = ext.lowercased()
+        switch lower {
+        case "mp4", "mov", "avi", "mkv", "wmv", "flv", "webm": return .video
+        case "mp3", "wav", "flac", "aac", "m4a", "ogg", "wma": return .audio
+        case "jpg", "jpeg", "png", "gif", "bmp", "tiff", "heic", "webp": return .images
+        case "pdf", "doc", "docx", "pages", "rtf", "txt", "odt": return .documents
+        case "xls", "xlsx", "numbers", "csv", "ods": return .documents
+        case "ppt", "pptx", "key": return .documents
+        case "zip", "gz", "tar", "rar", "7z", "bz2", "xz": return .archives
+        case "dmg", "iso", "img", "sparseimage": return .diskImages
+        case "app": return .applications
+        case "pkg", "mpkg": return .applications
+        case "swift", "h", "m", "mm", "c", "cpp", "py", "js", "ts",
+             "java", "rs", "go", "rb", "php", "css", "html", "sh",
+             "json", "xml", "yaml", "toml", "plist", "entitlements": return .code
+        case "kext", "dylib", "framework", "bundle": return .system
+        case "log", "cache", "db", "sqlite": return .system
+        default: return .other
+        }
+    }
+}
+
 /// A node in a treemap layout. Pure data.
 public struct TreemapNode: Sendable {
     public let name: String
     public let size: UInt64
     public let url: URL
     public let isDirectory: Bool
+    public let fileExtension: String
+    public let fileTypeCategory: FileTypeCategory
     public let children: [TreemapNode]
 
     public init(
@@ -14,12 +70,15 @@ public struct TreemapNode: Sendable {
         size: UInt64,
         url: URL,
         isDirectory: Bool,
-        children: [TreemapNode]
+        fileExtension: String = "",
+        children: [TreemapNode] = []
     ) {
         self.name = name
         self.size = size
         self.url = url
         self.isDirectory = isDirectory
+        self.fileExtension = fileExtension
+        self.fileTypeCategory = FileTypeCategory.category(forFileExtension: fileExtension, isDirectory: isDirectory)
         self.children = children
     }
 

--- a/Tests/MacCleanKitTests/FileTypeCategoryTests.swift
+++ b/Tests/MacCleanKitTests/FileTypeCategoryTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import Foundation
+@testable import MacCleanKit
+
+final class FileTypeCategoryTests: XCTestCase {
+
+    // MARK: - Directory detection
+
+    func testDirectoryReturnsFoldersCategory() {
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "", isDirectory: true), .folders)
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "mp4", isDirectory: true), .folders)
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "pdf", isDirectory: true), .folders)
+    }
+
+    // MARK: - Video files
+
+    func testVideoExtensions() {
+        for ext in ["mp4", "mov", "avi", "mkv", "wmv", "flv", "webm"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .video,
+                           "\(ext) should be .video")
+        }
+    }
+
+    // MARK: - Audio files
+
+    func testAudioExtensions() {
+        for ext in ["mp3", "wav", "flac", "aac", "m4a", "ogg", "wma"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .audio,
+                           "\(ext) should be .audio")
+        }
+    }
+
+    // MARK: - Images
+
+    func testImageExtensions() {
+        for ext in ["jpg", "jpeg", "png", "gif", "bmp", "tiff", "heic", "webp"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .images,
+                           "\(ext) should be .images")
+        }
+    }
+
+    // MARK: - Documents
+
+    func testDocumentExtensions() {
+        for ext in ["pdf", "doc", "docx", "pages", "rtf", "txt", "odt",
+                     "xls", "xlsx", "numbers", "csv", "ods",
+                     "ppt", "pptx", "key"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .documents,
+                           "\(ext) should be .documents")
+        }
+    }
+
+    // MARK: - Archives
+
+    func testArchiveExtensions() {
+        for ext in ["zip", "gz", "tar", "rar", "7z", "bz2", "xz"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .archives,
+                           "\(ext) should be .archives")
+        }
+    }
+
+    // MARK: - Disk Images
+
+    func testDiskImageExtensions() {
+        for ext in ["dmg", "iso", "img", "sparseimage"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .diskImages,
+                           "\(ext) should be .diskImages")
+        }
+    }
+
+    // MARK: - Applications
+
+    func testApplicationExtensions() {
+        for ext in ["app", "pkg", "mpkg"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .applications,
+                           "\(ext) should be .applications")
+        }
+    }
+
+    // MARK: - Code
+
+    func testCodeExtensions() {
+        for ext in ["swift", "h", "m", "mm", "c", "cpp", "py", "js", "ts",
+                     "java", "rs", "go", "rb", "php", "css", "html", "sh",
+                     "json", "xml", "yaml", "toml", "plist", "entitlements"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .code,
+                           "\(ext) should be .code")
+        }
+    }
+
+    // MARK: - System
+
+    func testSystemExtensions() {
+        for ext in ["kext", "dylib", "framework", "bundle", "log", "cache", "db", "sqlite"] {
+            XCTAssertEqual(FileTypeCategory.category(forFileExtension: ext, isDirectory: false), .system,
+                           "\(ext) should be .system")
+        }
+    }
+
+    // MARK: - Unknown / Other
+
+    func testUnknownExtensionReturnsOther() {
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "xyz", isDirectory: false), .other)
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "abc123", isDirectory: false), .other)
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "", isDirectory: false), .other)
+    }
+
+    // MARK: - Case insensitivity
+
+    func testCategoryIsCaseInsensitive() {
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "MP4", isDirectory: false), .video)
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "PDF", isDirectory: false), .documents)
+        XCTAssertEqual(FileTypeCategory.category(forFileExtension: "ZIP", isDirectory: false), .archives)
+    }
+
+    // MARK: - Category labels
+
+    func testCategoryLabels() {
+        XCTAssertEqual(FileTypeCategory.folders.label, "Folders")
+        XCTAssertEqual(FileTypeCategory.documents.label, "Documents")
+        XCTAssertEqual(FileTypeCategory.images.label, "Images")
+        XCTAssertEqual(FileTypeCategory.video.label, "Video")
+        XCTAssertEqual(FileTypeCategory.audio.label, "Audio")
+        XCTAssertEqual(FileTypeCategory.archives.label, "Archives")
+        XCTAssertEqual(FileTypeCategory.code.label, "Code")
+        XCTAssertEqual(FileTypeCategory.diskImages.label, "Disk Images")
+        XCTAssertEqual(FileTypeCategory.applications.label, "Applications")
+        XCTAssertEqual(FileTypeCategory.system.label, "System")
+        XCTAssertEqual(FileTypeCategory.other.label, "Other")
+    }
+
+    // MARK: - All cases present
+
+    func testAllCasesCovered() {
+        // Every FileTypeCategory case should produce the right label
+        let cases = FileTypeCategory.allCases
+        XCTAssertEqual(cases.count, 11)
+        XCTAssertTrue(cases.contains(.folders))
+        XCTAssertTrue(cases.contains(.other))
+    }
+}


### PR DESCRIPTION
## Summary

Optimize Space Lens to be more like Space Sniffer on Windows — color treemap cells by file type category instead of arbitrary hash-based cycling. This makes it much easier to visually identify what's consuming disk space.

## Changes

- **FileTypeCategory enum** (MacCleanKit): 11 categories (folders, documents, images, video, audio, archives, code, disk images, applications, system, other) with extension-to-category mapping
- **FileNode**: added `fileExtension` property captured at scan time
- **TreemapNode**: added `fileExtension` and `fileTypeCategory` properties
- **SpaceLensView**: replaced hash-based color cycling with category-based coloring; added file type legend beneath the treemap; shows total directory size in header; uses responsive canvas bounds instead of hardcoded 700x400
- **FileTypeCategoryTests**: 14 new unit tests covering all categories, case insensitivity, and edge cases

## Test Plan

- `swift build` — zero errors, zero new warnings
- `swift test` — 0 failures (34 Space Lens related tests + 14 new tests)
- Existing SquarifiedTreemapTests (11), SpaceLensNavigationTests (5), and ModuleE2ETests (4) all pass

Closes #90