### PR TITLE
Add regression coverage for large and old file selection

### DIFF
--- a/Sources/MacClean/Modules/LargeOldFiles/LargeOldFilesModule.swift
+++ b/Sources/MacClean/Modules/LargeOldFiles/LargeOldFilesModule.swift
@@ -43,14 +43,20 @@ public struct LargeOldFilesModule: ScanModule {
         let items = await scanner.scan(targets: targets)
         let split = Self.splitLargeAndOld(items: items, minSize: minSize)
 
+        return Self.makeResults(large: split.large, old: split.old).filteringUncleanable()
+    }
+
+    /// Pure result builder for testability. Large and old files always require
+    /// explicit user selection before cleaning.
+    internal static func makeResults(large: [FileItem], old: [FileItem]) -> [ScanResult] {
         var results: [ScanResult] = []
-        if !split.large.isEmpty {
-            results.append(ScanResult(category: .largeFiles, items: split.large, autoSelect: false))
+        if !large.isEmpty {
+            results.append(ScanResult(category: .largeFiles, items: large, autoSelect: false))
         }
-        if !split.old.isEmpty {
-            results.append(ScanResult(category: .oldFiles, items: split.old, autoSelect: false))
+        if !old.isEmpty {
+            results.append(ScanResult(category: .oldFiles, items: old, autoSelect: false))
         }
-        return results.filteringUncleanable()
+        return results
     }
 
     /// Pure splitter for testability: classifies file items into "large" and "old"

--- a/Sources/MacClean/Modules/LargeOldFiles/LargeOldFilesModule.swift
+++ b/Sources/MacClean/Modules/LargeOldFiles/LargeOldFilesModule.swift
@@ -48,6 +48,11 @@ public struct LargeOldFilesModule: ScanModule {
 
     /// Pure result builder for testability. Large and old files always require
     /// explicit user selection before cleaning.
+    ///
+    /// Returns the results *unfiltered*: callers must apply
+    /// `filteringUncleanable()` before showing them (see `scan()`). That step is
+    /// deliberately kept out here so this builder stays pure and can be tested
+    /// with synthetic items that don't exist on disk.
     internal static func makeResults(large: [FileItem], old: [FileItem]) -> [ScanResult] {
         var results: [ScanResult] = []
         if !large.isEmpty {

--- a/Tests/MacCleanTests/LargeOldFilesModuleTests.swift
+++ b/Tests/MacCleanTests/LargeOldFilesModuleTests.swift
@@ -13,6 +13,15 @@ final class LargeOldFilesSplitterTests: XCTestCase {
         )
     }
 
+    private func makeFile(at path: String, size: UInt64, mod: Date? = nil) -> FileItem {
+        FileItem(
+            url: URL(filePath: path),
+            name: URL(filePath: path).lastPathComponent,
+            size: size, allocatedSize: size,
+            isDirectory: false, modificationDate: mod
+        )
+    }
+
     func testSplitLargeAndOld_classifies() {
         let now = Date()
         let yearOld = now.addingTimeInterval(-365 * 24 * 3600)
@@ -55,5 +64,29 @@ final class LargeOldFilesSplitterTests: XCTestCase {
         let split = LargeOldFilesModule.splitLargeAndOld(items: items, minSize: 50 * 1024 * 1024)
         XCTAssertEqual(split.large.count, 1)
         XCTAssertEqual(split.old.count, 0)
+    }
+
+    func testMakeResultsPreservesBucketsWithoutAutoSelection() {
+        let documents = makeFile(at: "/Users/test/Documents/archive.mov", size: 200)
+        let desktop = makeFile(at: "/Users/test/Desktop/notes.txt", size: 20)
+        let pictures = makeFile(at: "/Users/test/Pictures/photo.raw", size: 100)
+
+        let results = LargeOldFilesModule.makeResults(
+            large: [documents, pictures],
+            old: [desktop, pictures]
+        )
+
+        XCTAssertEqual(results.map(\.category), [.largeFiles, .oldFiles])
+        XCTAssertEqual(results.map(\.items), [[documents, pictures], [desktop, pictures]])
+        XCTAssertEqual(results.map(\.autoSelect), [false, false])
+        XCTAssertTrue(LargeOldFilesModule.makeResults(large: [], old: []).isEmpty)
+        XCTAssertEqual(
+            LargeOldFilesModule.makeResults(large: [documents], old: []).map(\.category),
+            [.largeFiles]
+        )
+        XCTAssertEqual(
+            LargeOldFilesModule.makeResults(large: [], old: [desktop]).map(\.category),
+            [.oldFiles]
+        )
     }
 }


### PR DESCRIPTION
## Summary

Large & Old Files results already set `autoSelect: false`. This PR preserves that behavior while extracting the existing result construction into an internal pure helper and adding regression coverage so results for files in Documents, Desktop, and Pictures cannot silently become auto-selected.

Refs #11.

## Changes

- Extract the existing `.largeFiles` and `.oldFiles` result construction into `makeResults(large:old:)`
- Keep result filtering in `scan()` after the pure builder, preserving runtime behavior and ordering
- Add focused coverage for Documents, Desktop, and Pictures items, both result categories, shared items, and empty buckets
- Assert both result categories explicitly retain `autoSelect == false`

## Test Plan

- [x] RED: focused compilation failed because `LargeOldFilesModule.makeResults` did not exist
- [x] `swift test --filter LargeOldFilesSplitterTests` (5 tests, 0 failures)
- [x] `swift build`
- [x] `swift test --enable-code-coverage` (610 tests, 1 skipped, 0 failures)
- [x] `bash scripts/check-version-sync.sh`
- [x] CI-equivalent coverage-profile, safety-file, secret, deletion, and network checks
- [x] `git diff --check` and parse checks for both changed Swift files

## Screenshots

Not applicable. This change does not alter the UI or runtime selection behavior.

## Checklist

- [x] Code compiles with `swift build`
- [x] Business logic is isolated in a pure helper
- [x] No force unwrapping added
- [x] File operations and safety filtering are unchanged
- [x] No telemetry, network calls, or dependencies added
- [x] PR is focused on the regression seam and coverage
