### PR TITLE
Cask: quit running app on upgrade (clean replace)

### DIFF
--- a/Casks/mac-sai.rb
+++ b/Casks/mac-sai.rb
@@ -21,6 +21,10 @@ cask "mac-sai" do
 
   app "Mac Sai.app"
 
+  # Quit a running Mac Sai before upgrading/uninstalling so the old copy is
+  # cleanly replaced instead of lingering (macOS can't swap a running app).
+  uninstall quit: "com.macclean.app"
+
   zap trash: [
     "~/Library/Application Support/MacClean",
     "~/Library/Caches/com.macclean.app",


### PR DESCRIPTION
User reported that a `brew upgrade` left the old version behind instead of replacing it. macOS can't swap a running .app, so if Mac Sai is open during an upgrade, the old copy lingers.

Add `uninstall quit: "com.macclean.app"` to the cask so Homebrew quits the running app first, then installs the new version cleanly.

This is the tap template (`Casks/mac-sai.rb`); the release pipeline propagates it to the tap on the next release. The official homebrew-cask entry needs the same stanza via a separate one-line PR (autobump only updates version/sha, it won't add stanzas). No binary change, no version bump.