### PR TITLE
Fix #52: add Reset to Defaults in the Uninstaller

### DIFF
--- a/Sources/MacClean/Views/Applications/AppReset.swift
+++ b/Sources/MacClean/Views/Applications/AppReset.swift
@@ -1,0 +1,24 @@
+import Foundation
+import MacCleanKit
+
+/// Pure reset-to-defaults plan, kept out of the view so it's testable.
+///
+/// Issue #52: the Uninstaller's Reset button used to only clear UI selection.
+/// This builds the clean plan for a real reset: selected leftovers that
+/// `AppResetPolicy` marks resetable. The `.app` bundle is never included.
+enum AppReset {
+    /// Returns `nil` when nothing selected is resetable (button should be disabled).
+    static func plan(
+        app: AppInfo,
+        associatedFiles: [FileItem],
+        selectedFiles: Set<URL>
+    ) -> (items: [FileItem], selection: Set<URL>)? {
+        let items = AppResetPolicy.resetableItems(
+            from: associatedFiles,
+            selected: selectedFiles,
+            appBundle: app.path
+        )
+        guard !items.isEmpty else { return nil }
+        return (items, Set(items.map(\.url)))
+    }
+}

--- a/Sources/MacClean/Views/Applications/UninstallerView.swift
+++ b/Sources/MacClean/Views/Applications/UninstallerView.swift
@@ -12,8 +12,11 @@ struct UninstallerView: View {
     @State private var isLoading = true
     @State private var isLoadingFiles = false
     @State private var isUninstalling = false
+    @State private var isResetting = false
     @State private var appPendingUninstall: AppInfo?
+    @State private var appPendingReset: AppInfo?
     @State private var uninstallError: String?
+    @State private var resetError: String?
     @State private var filter: AppFilter = .all
     @State private var searchText = ""
 
@@ -121,6 +124,37 @@ struct UninstallerView: View {
         } message: {
             Text(uninstallError ?? "")
         }
+        .alert(
+            L10n.tr(
+                "将 \(appPendingReset?.name ?? "此应用") 恢复为默认设置？",
+                "Reset \(appPendingReset?.name ?? "this app") to defaults?",
+                "Сбросить \(appPendingReset?.name ?? "это приложение") к настройкам по умолчанию?"
+            ),
+            isPresented: Binding(get: { appPendingReset != nil },
+                                 set: { if !$0 { appPendingReset = nil } }),
+            presenting: appPendingReset
+        ) { app in
+            Button(L10n.tr("取消", "Cancel", "Отмена"), role: .cancel) { appPendingReset = nil }
+            Button(L10n.tr("恢复默认", "Reset to Defaults", "Сбросить настройки"), role: .destructive) {
+                let target = app; appPendingReset = nil; resetToDefaults(target)
+            }
+        } message: { app in
+            let plan = AppReset.plan(app: app, associatedFiles: associatedFiles, selectedFiles: selectedFiles)
+            let count = plan?.items.count ?? 0
+            let bytes = plan?.items.reduce(0 as UInt64) { $0 + $1.size } ?? 0
+            Text(L10n.tr(
+                "将把 \(app.name) 的缓存、偏好设置和保存的状态（\(count) 项，\(FileSizeFormatter.format(bytes))）移到废纸篓。应用本身会保留。若应用正在运行，请先退出，否则它可能会重新写入这些文件。",
+                "Caches, preferences, and saved state for \(app.name) (\(count) items, \(FileSizeFormatter.format(bytes))) will be moved to the Trash. The app stays installed. Quit the app first if it is running, or it may rewrite these files.",
+                "Кэш, настройки и сохранённое состояние \(app.name) (\(count) \(L10n.russianPlural(count, one: "объект", few: "объекта", many: "объектов")), \(FileSizeFormatter.format(bytes))) будут перемещены в Корзину. Само приложение останется. Если оно запущено, сначала закройте его — иначе файлы могут быть записаны заново."
+            ))
+        }
+        .alert(L10n.tr("恢复默认", "Reset to Defaults", "Сброс настроек"),
+               isPresented: Binding(get: { resetError != nil },
+                                    set: { if !$0 { resetError = nil } })) {
+            Button(L10n.tr("好", "OK"), role: .cancel) { resetError = nil }
+        } message: {
+            Text(resetError ?? "")
+        }
     }
 
     private var filteredApps: [AppInfo] {
@@ -196,27 +230,39 @@ struct UninstallerView: View {
                 }
                 Spacer()
 
-                if safetyGuard.isProtectedApp(app.bundleIdentifier) {
-                    Text(L10n.tr("受保护的系统应用——无法移除", "Protected system app — can't be removed", "Защищённое системное приложение — удалить нельзя"))
-                        .font(.system(size: 12))
-                        .foregroundStyle(.primary.opacity(0.6))
-                } else if isUninstalling {
+                if isUninstalling || isResetting {
                     // In-progress feedback: the button is gone (can't be
                     // re-tapped) and a spinner shows the work is happening.
                     ProgressView()
                         .controlSize(.small)
-                    Text(L10n.tr("正在卸载…", "Uninstalling…", "Удаление…"))
+                    Text(isResetting
+                         ? L10n.tr("正在恢复默认…", "Resetting…", "Сброс…")
+                         : L10n.tr("正在卸载…", "Uninstalling…", "Удаление…"))
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                 } else {
-                    Button(L10n.tr("卸载", "Uninstall", "Удалить")) { appPendingUninstall = app }
-                        .buttonStyle(.borderedProminent)
-                        .tint(.red)
-                        .controlSize(.small)
+                    if safetyGuard.isProtectedApp(app.bundleIdentifier) {
+                        Text(L10n.tr("受保护的系统应用——无法移除", "Protected system app — can't be removed", "Защищённое системное приложение — удалить нельзя"))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.primary.opacity(0.6))
+                    } else {
+                        Button(L10n.tr("卸载", "Uninstall", "Удалить")) { appPendingUninstall = app }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.red)
+                            .controlSize(.small)
+                    }
 
-                    Button(L10n.tr("重置", "Reset", "Сбросить")) { resetSelection() }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
+                    Button(L10n.tr("恢复默认", "Reset to Defaults", "Сбросить настройки")) {
+                        appPendingReset = app
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(AppReset.plan(app: app, associatedFiles: associatedFiles, selectedFiles: selectedFiles) == nil)
+                    .help(L10n.tr(
+                        "清除缓存、偏好设置和保存的状态，保留应用本身。",
+                        "Clears caches, preferences, and saved state. The app stays installed.",
+                        "Очищает кэш, настройки и сохранённое состояние. Само приложение остаётся."
+                    ))
                 }
             }
             .padding()
@@ -276,11 +322,31 @@ struct UninstallerView: View {
         }
     }
 
-    private func resetSelection() {
-        selectedApp = nil
-        associatedFiles = []
-        selectedFiles = []
-        isLoadingFiles = false
+    private func resetToDefaults(_ app: AppInfo) {
+        guard !isResetting, !isUninstalling else { return }
+        guard let plan = AppReset.plan(
+            app: app,
+            associatedFiles: associatedFiles,
+            selectedFiles: selectedFiles
+        ) else { return }
+
+        isResetting = true
+        Task {
+            let result = await CleanActions.executeUserClean(
+                items: plan.items,
+                selectedItems: plan.selection,
+                engine: appState.cleaningEngine
+            )
+            if !result.errors.isEmpty {
+                resetError = L10n.tr(
+                    "恢复 \(app.name) 的默认设置时部分项目失败（\(result.errors.count) 个）。请确认应用已退出后重试。",
+                    "Some items couldn't be reset for \(app.name) (\(result.errors.count)). Quit the app if it is running and try again.",
+                    "Не удалось сбросить часть данных \(app.name) (\(result.errors.count)). Закройте приложение, если оно запущено, и повторите попытку."
+                )
+            }
+            loadAssociatedFiles(for: app)
+            isResetting = false
+        }
     }
 
     private func loadApps() async {

--- a/Sources/MacCleanKit/AppResetPolicy.swift
+++ b/Sources/MacCleanKit/AppResetPolicy.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Classifies Uninstaller leftover paths for “Reset to Defaults” (issue #52).
+///
+/// Reset restores a fresh-install *settings* state: caches, preferences, and
+/// saved application state (plus closely related regenerable session data).
+/// It never touches the `.app` bundle, Application Support / Containers
+/// (licenses, databases, documents), or launch agents / plug-ins / helpers.
+///
+/// Pure: no FileManager. Path roots come from `MCConstants` so tests can
+/// assert against the same prefixes SafetyGuard uses.
+public enum AppResetPolicy {
+
+    public enum Decision: Equatable, Sendable {
+        case resetable
+        case keepBundle
+        case keepUserData
+        case keepSystemIntegration
+    }
+
+    public static func isResetable(url: URL, appBundle: URL) -> Bool {
+        decision(for: url, appBundle: appBundle) == .resetable
+    }
+
+    public static func decision(for url: URL, appBundle: URL) -> Decision {
+        let path = url.path(percentEncoded: false)
+        let bundlePath = appBundle.path(percentEncoded: false)
+        if isInside(path, root: bundlePath) {
+            return .keepBundle
+        }
+        if isUnderAny(path, of: resetableRoots) {
+            return .resetable
+        }
+        if isUnderAny(path, of: userDataRoots) {
+            return .keepUserData
+        }
+        return .keepSystemIntegration
+    }
+
+    /// Intersection of the user's checkbox selection with resetable leftovers.
+    /// The app bundle is never returned, even if it was selected.
+    public static func resetableItems(
+        from associatedFiles: [FileItem],
+        selected: Set<URL>,
+        appBundle: URL
+    ) -> [FileItem] {
+        associatedFiles.filter { item in
+            selected.contains(item.url) && isResetable(url: item.url, appBundle: appBundle)
+        }
+    }
+
+    // MARK: - Roots
+
+    private static let resetableRoots: [URL] = [
+        MCConstants.userCaches,
+        MCConstants.userPreferences,
+        MCConstants.userSavedAppState,
+        MCConstants.userLogs,
+        MCConstants.userCookies,
+        MCConstants.userHTTPStorages,
+        MCConstants.userWebKit,
+    ]
+
+    private static let userDataRoots: [URL] = [
+        MCConstants.userAppSupport,
+        MCConstants.userContainers,
+        MCConstants.userGroupContainers,
+        MCConstants.userAppScripts,
+    ]
+
+    /// True if `path` is `root` or a descendant, using a `/` boundary so
+    /// `.../Caches` does not match `.../CachesEvil`.
+    private static func isInside(_ path: String, root: String) -> Bool {
+        if path == root { return true }
+        let prefix = root.hasSuffix("/") ? root : root + "/"
+        return path.hasPrefix(prefix)
+    }
+
+    private static func isUnderAny(_ path: String, of roots: [URL]) -> Bool {
+        roots.contains { isInside(path, root: $0.path(percentEncoded: false)) }
+    }
+}

--- a/Tests/MacCleanKitTests/AppResetPolicyTests.swift
+++ b/Tests/MacCleanKitTests/AppResetPolicyTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import MacCleanKit
+
+final class AppResetPolicyTests: XCTestCase {
+
+    private let bundle = URL(filePath: "/Applications/Foo.app")
+
+    private func item(_ path: String) -> URL {
+        URL(filePath: path)
+    }
+
+    private func homeLibrary(_ subdir: String, _ name: String) -> URL {
+        MCConstants.userLibrary.appending(path: subdir).appending(path: name)
+    }
+
+    // MARK: - Resetable (issue #52: caches, preferences, saved state)
+
+    func testCachesAreResetable() {
+        let url = homeLibrary("Caches", "com.example.foo")
+        XCTAssertEqual(AppResetPolicy.decision(for: url, appBundle: bundle), .resetable)
+        XCTAssertTrue(AppResetPolicy.isResetable(url: url, appBundle: bundle))
+    }
+
+    func testPreferencesAreResetable() {
+        let url = homeLibrary("Preferences", "com.example.foo.plist")
+        XCTAssertEqual(AppResetPolicy.decision(for: url, appBundle: bundle), .resetable)
+    }
+
+    func testSavedApplicationStateIsResetable() {
+        let url = homeLibrary("Saved Application State", "com.example.foo.savedState")
+        XCTAssertEqual(AppResetPolicy.decision(for: url, appBundle: bundle), .resetable)
+    }
+
+    func testLogsCookiesHTTPStoragesWebKitAreResetable() {
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("Logs", "Foo.log"), appBundle: bundle),
+            .resetable
+        )
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("Cookies", "com.example.foo.binarycookies"), appBundle: bundle),
+            .resetable
+        )
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("HTTPStorages", "com.example.foo"), appBundle: bundle),
+            .resetable
+        )
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("WebKit", "com.example.foo"), appBundle: bundle),
+            .resetable
+        )
+    }
+
+    // MARK: - Never the bundle
+
+    func testAppBundleIsNeverResetable() {
+        XCTAssertEqual(AppResetPolicy.decision(for: bundle, appBundle: bundle), .keepBundle)
+        XCTAssertFalse(AppResetPolicy.isResetable(url: bundle, appBundle: bundle))
+    }
+
+    func testFileInsideAppBundleIsNeverResetable() {
+        let nested = bundle.appending(path: "Contents/Info.plist")
+        XCTAssertEqual(AppResetPolicy.decision(for: nested, appBundle: bundle), .keepBundle)
+    }
+
+    // MARK: - User data (fresh-install v1 does not wipe documents / licenses)
+
+    func testApplicationSupportIsKept() {
+        let url = homeLibrary("Application Support", "Foo")
+        XCTAssertEqual(AppResetPolicy.decision(for: url, appBundle: bundle), .keepUserData)
+        XCTAssertFalse(AppResetPolicy.isResetable(url: url, appBundle: bundle))
+    }
+
+    func testContainersAreKept() {
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("Containers", "com.example.foo"), appBundle: bundle),
+            .keepUserData
+        )
+        XCTAssertEqual(
+            AppResetPolicy.decision(
+                for: homeLibrary("Group Containers", "group.com.example.foo"),
+                appBundle: bundle
+            ),
+            .keepUserData
+        )
+    }
+
+    func testApplicationScriptsAreKept() {
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("Application Scripts", "com.example.foo"), appBundle: bundle),
+            .keepUserData
+        )
+    }
+
+    // MARK: - System integration
+
+    func testLaunchAgentsAreKept() {
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("LaunchAgents", "com.example.foo.plist"), appBundle: bundle),
+            .keepSystemIntegration
+        )
+    }
+
+    func testPlugInsAndHelpersAreKept() {
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("Internet Plug-Ins", "Foo.plugin"), appBundle: bundle),
+            .keepSystemIntegration
+        )
+        XCTAssertEqual(
+            AppResetPolicy.decision(for: homeLibrary("PreferencePanes", "Foo.prefPane"), appBundle: bundle),
+            .keepSystemIntegration
+        )
+        XCTAssertEqual(
+            AppResetPolicy.decision(
+                for: homeLibrary("PrivilegedHelperTools", "com.example.foo"),
+                appBundle: bundle
+            ),
+            .keepSystemIntegration
+        )
+    }
+
+    func testSystemLaunchDaemonIsKept() {
+        let url = URL(filePath: "/Library/LaunchDaemons/com.example.foo.plist")
+        XCTAssertEqual(AppResetPolicy.decision(for: url, appBundle: bundle), .keepSystemIntegration)
+    }
+
+    // MARK: - Prefix boundary (Caches vs CachesEvil)
+
+    func testCachePrefixDoesNotMatchSiblingDirectory() {
+        let sibling = MCConstants.userLibrary.appending(path: "CachesEvil").appending(path: "com.example.foo")
+        XCTAssertNotEqual(AppResetPolicy.decision(for: sibling, appBundle: bundle), .resetable)
+    }
+
+    // MARK: - Filter
+
+    func testFilterKeepsOnlySelectedResetableItems() {
+        let cache = FileItem(
+            url: homeLibrary("Caches", "com.example.foo"),
+            name: "com.example.foo", size: 10, allocatedSize: 10, isDirectory: true
+        )
+        let prefs = FileItem(
+            url: homeLibrary("Preferences", "com.example.foo.plist"),
+            name: "com.example.foo.plist", size: 2, allocatedSize: 2, isDirectory: false
+        )
+        let support = FileItem(
+            url: homeLibrary("Application Support", "Foo"),
+            name: "Foo", size: 99, allocatedSize: 99, isDirectory: true
+        )
+        let bundleItem = FileItem(
+            url: bundle, name: "Foo.app", size: 1000, allocatedSize: 1000, isDirectory: true
+        )
+
+        let filtered = AppResetPolicy.resetableItems(
+            from: [cache, prefs, support, bundleItem],
+            selected: [cache.url, support.url, bundle],
+            appBundle: bundle
+        )
+        XCTAssertEqual(filtered.map(\.url), [cache.url],
+                       "only selected resetable files; prefs was unchecked, support and bundle excluded")
+    }
+
+    func testFilterEmptyWhenNothingResetableSelected() {
+        let support = FileItem(
+            url: homeLibrary("Application Support", "Foo"),
+            name: "Foo", size: 99, allocatedSize: 99, isDirectory: true
+        )
+        let filtered = AppResetPolicy.resetableItems(
+            from: [support],
+            selected: [support.url],
+            appBundle: bundle
+        )
+        XCTAssertTrue(filtered.isEmpty)
+    }
+}

--- a/Tests/MacCleanTests/AppResetTests.swift
+++ b/Tests/MacCleanTests/AppResetTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+import Foundation
+@testable import MacClean
+@testable import MacCleanKit
+
+final class AppResetTests: XCTestCase {
+
+    private func app(_ bundleID: String = "com.example.foo",
+                     path: String = "/Applications/Foo.app") -> AppInfo {
+        AppInfo(bundleIdentifier: bundleID, name: "Foo",
+                path: URL(filePath: path), version: "1.0", size: 1000)
+    }
+
+    private func file(_ path: String, size: UInt64 = 10) -> FileItem {
+        FileItem(url: URL(filePath: path), name: URL(filePath: path).lastPathComponent,
+                 size: size, allocatedSize: size, isDirectory: true)
+    }
+
+    func testPlanOmitsAppBundleEvenIfSelected() {
+        let a = app()
+        let cache = file(MCConstants.userCaches.appending(path: "com.example.foo").path(percentEncoded: false))
+        let plan = AppReset.plan(
+            app: a,
+            associatedFiles: [cache],
+            selectedFiles: [cache.url, a.path]
+        )
+        XCTAssertFalse(plan?.selection.contains(a.path) ?? true,
+                       "reset must never trash the app bundle")
+        XCTAssertEqual(plan?.items.map(\.url), [cache.url])
+    }
+
+    func testPlanNilWhenOnlyUserDataSelected() {
+        let a = app()
+        let support = file(MCConstants.userAppSupport.appending(path: "Foo").path(percentEncoded: false))
+        XCTAssertNil(AppReset.plan(app: a, associatedFiles: [support], selectedFiles: [support.url]),
+                     "Application Support is not part of reset-to-defaults")
+    }
+
+    func testPlanNilWhenSelectionEmpty() {
+        let a = app()
+        let cache = file(MCConstants.userCaches.appending(path: "com.example.foo").path(percentEncoded: false))
+        XCTAssertNil(AppReset.plan(app: a, associatedFiles: [cache], selectedFiles: []))
+    }
+
+    func testProtectedAppleAppCanStillBeReset() {
+        // Uninstall refuses Finder; reset of its caches/prefs is allowed.
+        let a = app("com.apple.finder", path: "/System/Applications/Finder.app")
+        let cache = file(MCConstants.userCaches.appending(path: "com.apple.finder").path(percentEncoded: false))
+        let plan = AppReset.plan(app: a, associatedFiles: [cache], selectedFiles: [cache.url])
+        XCTAssertEqual(plan?.items.map(\.url), [cache.url])
+        XCTAssertNil(AppUninstaller.plan(app: a, associatedFiles: [cache], selectedFiles: [cache.url]),
+                     "uninstall must still refuse the protected app")
+    }
+
+    func testPlanIntersectsSelectionWithPolicy() {
+        let a = app()
+        let cache = file(MCConstants.userCaches.appending(path: "com.example.foo").path(percentEncoded: false))
+        let prefs = file(MCConstants.userPreferences.appending(path: "com.example.foo.plist").path(percentEncoded: false), size: 2)
+        let agents = file(MCConstants.userLaunchAgents.appending(path: "com.example.foo.plist").path(percentEncoded: false))
+        let plan = AppReset.plan(
+            app: a,
+            associatedFiles: [cache, prefs, agents],
+            selectedFiles: [cache.url, agents.url]
+        )
+        XCTAssertEqual(Set(plan?.items.map(\.url) ?? []), [cache.url],
+                       "unchecked prefs stay; launch agents never reset")
+    }
+
+    /// Source guard: the Uninstaller Reset control must call AppReset, not
+    /// the old `resetSelection()` that only cleared the UI.
+    func testUninstallerViewWiresRealReset() throws {
+        let url = URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: "Sources/MacClean/Views/Applications/UninstallerView.swift")
+        let src = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(src.contains("AppReset.plan"),
+                      "UninstallerView must build a reset plan via AppReset.plan")
+        XCTAssertTrue(src.contains("executeUserClean"),
+                      "reset must go through CleanActions.executeUserClean")
+        XCTAssertFalse(
+            src.contains("Button(L10n.tr(\"重置\", \"Reset\", \"Сбросить\")) { resetSelection() }"),
+            "the Reset button must no longer only clear UI selection"
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-08-12-reset-app-defaults.md
+++ b/docs/superpowers/plans/2026-08-12-reset-app-defaults.md
@@ -1,0 +1,39 @@
+# Reset App to Defaults (#52) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Real “Reset to Defaults” in the Uninstaller: trash caches/prefs/saved state, keep the app.
+
+**Architecture:** Pure `AppResetPolicy` in MacCleanKit; `AppReset.plan` in MacClean (mirrors `AppUninstaller`); UninstallerView confirmation + `CleanActions.executeUserClean`.
+
+**Tech Stack:** Swift 6, SwiftUI, XCTest, SafetyGuard, CleaningEngine
+
+## Global Constraints
+
+- One feature per PR (CONTRIBUTING).
+- Business logic in MacCleanKit; I/O stays in MacClean.
+- File deletion only via SafetyGuard + CleaningEngine (`.trash`, never `.dryRun`).
+- No force unwraps in production code.
+- New strings via `L10n.tr(zh, en, ru)`.
+- Do not modify `SafetyGuard` protected-path lists.
+
+## Files
+
+| File | Role |
+|---|---|
+| `Sources/MacCleanKit/AppResetPolicy.swift` | Pure classify / filter |
+| `Sources/MacClean/Views/Applications/AppReset.swift` | Plan from selection |
+| `Sources/MacClean/Views/Applications/UninstallerView.swift` | Button + alert + action |
+| `Tests/MacCleanKitTests/AppResetPolicyTests.swift` | Classification + adversarial |
+| `Tests/MacCleanTests/AppResetTests.swift` | Plan never includes bundle / user data |
+
+## Tasks
+
+- [x] Spec written
+- [x] RED: AppResetPolicyTests
+- [x] GREEN: AppResetPolicy
+- [x] RED: AppResetTests
+- [x] GREEN: AppReset.plan
+- [x] Wire UninstallerView
+- [x] `swift test` full suite (684 passed, 3 skipped, 0 failures)
+- [ ] PR

--- a/docs/superpowers/specs/2026-08-12-reset-app-defaults-design.md
+++ b/docs/superpowers/specs/2026-08-12-reset-app-defaults-design.md
@@ -1,0 +1,53 @@
+# Reset an app to defaults (#52)
+
+Date: 2026-08-12
+Status: Design (approved for implementation)
+
+## Problem
+
+The Uninstaller’s **Reset** button only clears the current selection in the UI
+(`resetSelection()`). Issue #52 asks for a real “fresh-install state” action:
+clear an app’s caches, preferences, and saved state **without** removing the
+`.app` bundle.
+
+## Goal
+
+Replace the misleading Reset control with **Reset to Defaults**: trash only
+user-library files that restore factory settings. The app stays installed.
+All deletion goes through `SafetyGuard` + `CleaningEngine` via `CleanActions`
+(trash-first, never `.dryRun`).
+
+## Non-goals
+
+- No new sidebar module.
+- Do not delete the app bundle, LaunchAgents/Daemons, plug-ins, preference
+  panes, privileged helpers, or Application Support / Containers (those hold
+  licenses, databases, and documents).
+- No change to uninstall behaviour or `SafetyGuard` protected-path lists.
+- No `Localizable.strings` migration; new copy uses `L10n.tr`.
+
+## Approach
+
+Pure policy in `MacCleanKit.AppResetPolicy` classifies each associated file:
+
+| Decision | Paths |
+|---|---|
+| **resetable** | `~/Library/Caches`, `Preferences`, `Saved Application State`, `Logs`, `Cookies`, `HTTPStorages`, `WebKit` |
+| **keepBundle** | the `.app` itself or anything inside it |
+| **keepUserData** | Application Support, Containers, Group Containers, Application Scripts |
+| **keepSystemIntegration** | LaunchAgents, plug-ins, helpers, anything else |
+
+`AppReset.plan` (MacClean, same shape as `AppUninstaller.plan`) intersects the
+user’s checkbox selection with resetable files. Empty plan → button disabled.
+
+Protected Apple apps **can** be reset (caches/prefs only). They still cannot
+be uninstalled.
+
+UI: confirmation alert (quit-first note), then `CleanActions.executeUserClean`.
+Reload associated files; keep the app selected. Surface engine errors.
+
+## Testing
+
+Kit unit tests for classification (including prefix-boundary and “never the
+bundle”). MacClean tests for `AppReset.plan`. Adversarial: Application Support,
+Containers, LaunchAgents, and the bundle must never enter the plan.


### PR DESCRIPTION
## Summary
The Uninstaller’s **Reset** button only cleared the current UI selection (`resetSelection()`). This PR implements issue #52: a real **Reset to Defaults** that restores a fresh-install *settings* state — caches, preferences, and saved application state — **without removing the app**.

Deletion is trash-first through `SafetyGuard` + `CleaningEngine` via `CleanActions.executeUserClean` (never `.dryRun`). The `.app` bundle is never in the plan, even if it is selected.

Design: `docs/superpowers/specs/2026-08-12-reset-app-defaults-design.md`.

## Changes
- `AppResetPolicy` (MacCleanKit, pure) classifies leftover paths:
  - **Resetable:** `~/Library/Caches`, `Preferences`, `Saved Application State`, `Logs`, `Cookies`, `HTTPStorages`, `WebKit`
  - **Kept:** the `.app` bundle, Application Support / Containers / Group Containers / Application Scripts (licenses, databases, documents), LaunchAgents, plug-ins, helpers
- `AppReset.plan` (same shape as `AppUninstaller.plan`) intersects the user’s checkboxes with that policy; empty plan disables the button
- Uninstaller UI: **Reset to Defaults** confirmation (count + size, quit-first note), spinner while running, error alert on partial failure; protected Apple apps can still be reset (uninstall remains blocked)
- Tests: 15 Kit classification/adversarial cases + 6 MacClean plan/source-guard cases

## Test Plan
- [x] `swift test` — **684 passed**, 3 skipped, **0 failures**
- [x] New tests: `AppResetPolicyTests`, `AppResetTests`
- [x] Adversarial: bundle, Application Support, Containers, LaunchAgents, `/Library/LaunchDaemons`, and `Caches` vs `CachesEvil` prefix never enter the reset plan
- [x] Protected app (`com.apple.finder`) can be reset; `AppUninstaller.plan` still returns `nil`
- [x] Source guard: UninstallerView no longer wires Reset to `resetSelection()`; it calls `AppReset.plan` + `executeUserClean`
- [x] No `.dryRun` in production views (`CleanIsNotDryRunRegressionTests`)
- [ ] In the running app: pick a third-party app with caches/prefs selected → Reset to Defaults → confirm items go to Trash and the `.app` remains; uncheck all resetable files → button disabled; Application Support stays on disk

## Screenshots
UI follows the existing Uninstaller confirmation pattern (destructive confirm + Cancel). New control label: **Reset to Defaults**, with a help tooltip explaining that the app stays installed.

## Checklist
- [x] Code compiles with `swift build` / `swift test`
- [x] Follows existing code style (Swift 6, no force unwraps)
- [x] File operations go through SafetyGuard/CleaningEngine
- [x] No telemetry or network calls added
- [x] PR is focused (one feature: #52)
- [x] Did not modify `SafetyGuard` protected-path lists

Fixes #52