### PR TITLE
AppMatching: never emit or match on an empty pattern (defensive)

### DIFF
--- a/Sources/MacCleanKit/AppMatching.swift
+++ b/Sources/MacCleanKit/AppMatching.swift
@@ -118,12 +118,20 @@ public enum AppMatching {
             }
         }
 
-        return patterns
+        // Never emit an empty pattern (e.g. an app with no CFBundleIdentifier
+        // inserts "" at the bundle-ID levels). An empty token is useless and,
+        // if the matcher ever stops relying on Foundation's contains semantics,
+        // would match every file.
+        return patterns.filter { !$0.isEmpty }
     }
 
     /// Returns true if `fileName` (lowercased) matches any of the patterns.
     public static func filenameMatches(_ fileName: String, patterns: Set<String>) -> Bool {
         let lower = fileName.lowercased()
-        return patterns.contains(where: { lower.contains($0) })
+        // Skip empty patterns defensively: a "" token would match every file.
+        // It is currently neutralised by Foundation's `String.contains("")`
+        // returning false, but this must not rely on that, since these patterns
+        // drive file deletion.
+        return patterns.contains(where: { !$0.isEmpty && lower.contains($0) })
     }
 }

--- a/Tests/MacCleanKitTests/AppMatchingTests.swift
+++ b/Tests/MacCleanKitTests/AppMatchingTests.swift
@@ -171,6 +171,44 @@ final class AppMatchingTests: XCTestCase {
                                                     patterns: ["chrome", "google"]))
     }
 
+    // MARK: - Empty / over-broad pattern hardening
+
+    // An app with an empty CFBundleIdentifier must never produce the empty
+    // pattern "": filenameMatches uses `contains`, and "x".contains("") is
+    // always true, so an empty pattern matches EVERY file and the uninstaller /
+    // reset would sweep up unrelated apps' caches and preferences.
+    func testEmptyBundleIDDoesNotProduceAnEmptyPattern() {
+        let app = AppInfo(
+            bundleIdentifier: "",
+            name: "Weird",
+            path: URL(filePath: "/Applications/Weird.app")
+        )
+        let patterns = AppMatching.generatePatterns(for: app)
+        XCTAssertFalse(patterns.contains(""),
+                       "empty bundle id must not yield a match-everything pattern")
+        XCTAssertFalse(patterns.contains(where: \.isEmpty))
+    }
+
+    func testEmptyBundleIDAppDoesNotOverMatchUnrelatedFiles() {
+        let app = AppInfo(
+            bundleIdentifier: "",
+            name: "Weird",
+            path: URL(filePath: "/Applications/Weird.app")
+        )
+        let patterns = AppMatching.generatePatterns(for: app)
+        // Files owned by unrelated apps must not match.
+        XCTAssertFalse(AppMatching.filenameMatches("com.google.chrome.plist", patterns: patterns))
+        XCTAssertFalse(AppMatching.filenameMatches("com.apple.finder.plist", patterns: patterns))
+        // Its own name still matches.
+        XCTAssertTrue(AppMatching.filenameMatches("weird-cache.db", patterns: patterns))
+    }
+
+    func testFilenameMatchesIgnoresEmptyPattern() {
+        // Defense in depth: even if an empty pattern is present it must never
+        // match everything.
+        XCTAssertFalse(AppMatching.filenameMatches("anything.plist", patterns: ["", "zzz"]))
+    }
+
     // MARK: - Library subdirectories list
 
     func testLibrarySubdirectoriesIncludesEssentials() {


### PR DESCRIPTION
Small defensive hardening in the app-matching engine used by the Uninstaller and the new Reset to Defaults.

## Honest context
While auditing #131 I flagged a possible over-match: an app with an **empty CFBundleIdentifier** inserts the pattern `""`, and `filenameMatches` uses `.contains()`. I then **verified it empirically, and it's a false positive**: `AppMatching` imports Foundation, and Foundation's `String.contains("")` returns `false`, so the empty token never matches any file. There is no over-match and no data-loss today. (Two of the tests here pass unchanged and document exactly that.)

## Why still do it
The safety of that empty token relies entirely on one subtle Foundation behavior, and these patterns drive **file deletion**. If the matcher is ever refactored (Swift-native contains, regex, prefix match, etc.), an empty pattern would silently become match-everything. So this removes the latent token rather than depend on `contains("")` staying false:
- `generatePatterns` filters out empty patterns before returning.
- `filenameMatches` skips empty patterns.

No behavior change for normal apps.

## Tests
- `testEmptyBundleIDDoesNotProduceAnEmptyPattern` (was the only red one) - generatePatterns no longer emits `""`.
- `testEmptyBundleIDAppDoesNotOverMatchUnrelatedFiles` / `testFilenameMatchesIgnoresEmptyPattern` - pass, documenting no over-match.
- Gate: build clean, `swift test` 761 passed / 3 skipped / 0 failures.