### PR TITLE
Fix Extensions hang + loading width, and clarify Duplicates consolidate mode

### DIFF
--- a/Sources/MacClean/Modules/Extensions/ManagedExtensionsClient.swift
+++ b/Sources/MacClean/Modules/Extensions/ManagedExtensionsClient.swift
@@ -163,19 +163,26 @@ struct ManagedExtensionsClient: Sendable {
     }
 
     private static func runPluginKit() async -> String {
+        captureStandardOutput(of: URL(filePath: "/usr/bin/pluginkit"), arguments: ["-m", "-v"])
+    }
+
+    /// Run a process and return its stdout, draining the pipe BEFORE
+    /// `waitUntilExit`. Reading after waiting deadlocks: a command with more
+    /// output than the ~64KB pipe buffer (pluginkit lists hundreds of plug-ins)
+    /// blocks writing while we block waiting, and the load never completes.
+    /// stderr is discarded to /dev/null so it can't fill and deadlock either.
+    static func captureStandardOutput(of executable: URL, arguments: [String]) -> String {
         let process = Process()
         let outputPipe = Pipe()
-        let errorPipe = Pipe()
-        process.executableURL = URL(filePath: "/usr/bin/pluginkit")
-        process.arguments = ["-m", "-v"]
+        process.executableURL = executable
+        process.arguments = arguments
         process.standardOutput = outputPipe
-        process.standardError = errorPipe
+        process.standardError = FileHandle.nullDevice
         do {
             try process.run()
+            let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
-            let stdout = String(data: outputPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-            if process.terminationStatus == 0, !stdout.isEmpty { return stdout }
-            return stdout
+            return String(data: data, encoding: .utf8) ?? ""
         } catch {
             return ""
         }

--- a/Sources/MacClean/Views/Applications/ExtensionsView.swift
+++ b/Sources/MacClean/Views/Applications/ExtensionsView.swift
@@ -117,17 +117,26 @@ struct ExtensionsView: View {
                 .foregroundStyle(.primary.opacity(0.4))
                 .listRowSeparator(.hidden)
             } else {
-                section(
-                    kind: .preferencePane,
-                    title: L10n.tr("偏好设置面板", "Preference Panes", "Панели настроек"),
-                    icon: "slider.horizontal.3"
-                )
-                section(
-                    kind: .internetPlugin,
-                    title: L10n.tr("Internet 插件", "Internet Plug-Ins", "Интернет-плагины"),
-                    icon: "puzzlepiece.extension"
-                )
-                safariSection
+                // Only show a section that actually has items, so empty
+                // categories don't read as "the feature found nothing / is
+                // broken". The whole-empty case is handled above.
+                if items.contains(where: { $0.kind == .preferencePane }) {
+                    section(
+                        kind: .preferencePane,
+                        title: L10n.tr("偏好设置面板", "Preference Panes", "Панели настроек"),
+                        icon: "slider.horizontal.3"
+                    )
+                }
+                if items.contains(where: { $0.kind == .internetPlugin }) {
+                    section(
+                        kind: .internetPlugin,
+                        title: L10n.tr("Internet 插件", "Internet Plug-Ins", "Интернет-плагины"),
+                        icon: "puzzlepiece.extension"
+                    )
+                }
+                if items.contains(where: { $0.kind == .safariExtension }) {
+                    safariSection
+                }
             }
         }
         .listStyle(.inset)

--- a/Sources/MacClean/Views/Applications/ExtensionsView.swift
+++ b/Sources/MacClean/Views/Applications/ExtensionsView.swift
@@ -51,6 +51,9 @@ struct ExtensionsView: View {
                             .foregroundStyle(.primary.opacity(0.6))
                         Spacer()
                     }
+                    // Fill the card like the list does; otherwise the container
+                    // shrinks to the text width instead of the fixed page width.
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
                     list
                 }

--- a/Sources/MacClean/Views/Files/DuplicatesView.swift
+++ b/Sources/MacClean/Views/Files/DuplicatesView.swift
@@ -89,6 +89,23 @@ struct DuplicatesView: View {
                                 .labelsHidden()
                                 .padding(.horizontal, 20)
 
+                                // Spell out how the two modes differ, otherwise
+                                // the list looks identical and it's unclear what
+                                // Consolidate does versus Remove.
+                                Text(actionMode == .consolidate
+                                    ? L10n.tr(
+                                        "所选副本会保留在原位并转为克隆，仅释放重复占用的空间，不删除任何文件。",
+                                        "Selected copies stay in place as clones. Only the wasted duplicate space is freed, nothing is deleted.",
+                                        "Выбранные копии остаются на месте как клоны. Освобождается только место, занятое дубликатами, ничего не удаляется.")
+                                    : L10n.tr(
+                                        "所选副本会被移到废纸篓，每组保留一个原件。",
+                                        "Selected copies are moved to the Trash, one original is kept per group.",
+                                        "Выбранные копии перемещаются в Корзину, в каждой группе остаётся один оригинал."))
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.primary.opacity(0.6))
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding(.horizontal, 20)
+
                                 DuplicateGroupsList(
                                     groups: displayGroups,
                                     selectedItems: $selectedItems,
@@ -96,7 +113,10 @@ struct DuplicatesView: View {
                                 )
                             }
                         )
-                    }
+                    },
+                    actionLabel: actionMode == .consolidate
+                        ? L10n.tr("合并", "Consolidate", "Объединить")
+                        : nil
                 )
             } else if completion != nil {
                 ModuleContainerView(

--- a/Sources/MacClean/Views/Shared/ModuleContainerView.swift
+++ b/Sources/MacClean/Views/Shared/ModuleContainerView.swift
@@ -46,6 +46,10 @@ struct ModuleContainerView: View {
     /// it to show a grouped, keep-the-original layout while reusing everything
     /// else. The closure should read/write the same `selectedItems` binding.
     let resultsContent: (() -> AnyView)?
+    /// Overrides the primary action button's label (default "Clean"). The
+    /// Duplicates module sets "Consolidate" when in consolidate mode so the
+    /// button reflects that it clones rather than deletes.
+    let actionLabel: String?
 
     init(
         title: String,
@@ -67,7 +71,8 @@ struct ModuleContainerView: View {
         onReset: @escaping () -> Void,
         onGrantAccess: (() -> Void)? = nil,
         confirmEmptyTrash: Bool = false,
-        resultsContent: (() -> AnyView)? = nil
+        resultsContent: (() -> AnyView)? = nil,
+        actionLabel: String? = nil
     ) {
         self.title = title
         self.subtitle = subtitle
@@ -89,6 +94,7 @@ struct ModuleContainerView: View {
         self.onGrantAccess = onGrantAccess
         self.confirmEmptyTrash = confirmEmptyTrash
         self.resultsContent = resultsContent
+        self.actionLabel = actionLabel
     }
 
     @State private var showLargeSelectionConfirm = false
@@ -303,7 +309,7 @@ struct ModuleContainerView: View {
                 SizeDisplay(size: totalSelected, label: L10n.tr("已选择"))
                     .foregroundStyle(.primary)
                 Spacer()
-                Button(L10n.tr("清理", "Clean", "Очистить")) {
+                Button(actionLabel ?? L10n.tr("清理", "Clean", "Очистить")) {
                     if confirmEmptyTrash {
                         // Trash Bins: permanent + irreversible — always confirm.
                         showEmptyTrashConfirm = true

--- a/Tests/MacCleanTests/ManagedExtensionsClientTests.swift
+++ b/Tests/MacCleanTests/ManagedExtensionsClientTests.swift
@@ -274,4 +274,16 @@ final class ManagedExtensionsClientTests: XCTestCase {
             reveal: { _ in }
         )
     }
+
+    // Regression: capturing a command whose output exceeds the ~64KB pipe
+    // buffer must not deadlock. Before the fix, waitUntilExit ran before the
+    // pipe was drained and the Extensions page hung on "Looking for extensions…".
+    func testCaptureStandardOutputDoesNotDeadlockOnLargeOutput() {
+        // ~205 KB of stdout, well past the pipe buffer.
+        let script = "for i in $(seq 1 5000); do echo aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; done"
+        let out = ManagedExtensionsClient.captureStandardOutput(
+            of: URL(filePath: "/bin/sh"), arguments: ["-c", script])
+        XCTAssertEqual(out.filter { $0 == "\n" }.count, 5000)
+        XCTAssertGreaterThan(out.count, 200_000)
+    }
 }


### PR DESCRIPTION
Three fixes found while dev-testing the unreleased 1.19.0.

## 1. Extensions module hung on "Looking for extensions…"
`ManagedExtensionsClient.runPluginKit` called `waitUntilExit()` **before** draining the stdout pipe. With ~460 plug-ins the output exceeds the 64KB pipe buffer, so `pluginkit` blocks writing while the app blocks waiting, a classic deadlock (confirmed by a live `sample`: stuck in `NSConcreteTask.waitUntilExit`). Fixed by draining the pipe first, via a reusable `captureStandardOutput` helper, and discarding stderr to `/dev/null` (a second latent deadlock). Regression test captures 205KB of output without hanging.

## 2. Extensions loading card was narrow
The loading `VStack` lacked `.frame(maxWidth:.infinity, maxHeight:.infinity)`, so the card shrank to the text width while the loaded list filled the page. Now it fills like the list.

## 3. Duplicates: consolidate vs remove looked identical
Toggling the mode changed nothing visible. Added a caption that explains each mode ("moved to Trash" vs "kept as clones, only wasted space freed"), and the primary button now reads **Consolidate** in consolidate mode (new optional `actionLabel` on `ModuleContainerView`; default unchanged for every other module).

Gate: build clean, `swift test` 762 passed / 3 skipped / 0 failures.