### PR TITLE
Fix universal-binary thinning blind spot, dead deleted-users scan, malware signature drift, and 0-byte memory readout

### DIFF
--- a/Sources/MacClean/Modules/Malware/RealTimeMalwareMonitor.swift
+++ b/Sources/MacClean/Modules/Malware/RealTimeMalwareMonitor.swift
@@ -23,13 +23,6 @@ public final class RealTimeMalwareMonitor: @unchecked Sendable {
         MCConstants.userAppSupport.path(percentEncoded: false),
     ]
 
-    private let knownMalwarePatterns = [
-        "genio", "pirrit", "shlayer", "bundlore", "adload",
-        "mackeeper", "macdefender", "macprotector", "macguard",
-        "searchbaron", "searchmarquis", "searchmine",
-        "crossrider", "cimpli",
-    ]
-
     public init() {}
 
     public func start(alertHandler: @escaping (MalwareAlert) -> Void) {
@@ -55,8 +48,11 @@ public final class RealTimeMalwareMonitor: @unchecked Sendable {
             let path = change.path
             let name = URL(filePath: path).lastPathComponent.lowercased()
 
-            // Check against known malware patterns
-            for pattern in knownMalwarePatterns {
+            // Check against known malware patterns. Sourced from
+            // MalwareSignatures — the single list also used by the
+            // on-demand MalwareModule scan, so the two detection paths
+            // can never drift out of sync with each other again.
+            for pattern in MalwareSignatures.knownPatterns {
                 if name.contains(pattern) {
                     alertHandler?(MalwareAlert(
                         path: path,
@@ -95,9 +91,10 @@ public final class RealTimeMalwareMonitor: @unchecked Sendable {
         else { return }
 
         let joined = args.joined(separator: " ").lowercased()
-        let suspiciousPatterns = ["curl ", "wget ", "python -c", "osascript", "/tmp/", "base64"]
 
-        for pattern in suspiciousPatterns {
+        // Sourced from MalwareSignatures — see the comment in
+        // handleChanges above.
+        for pattern in MalwareSignatures.suspiciousLaunchAgentSubstrings {
             if joined.contains(pattern) {
                 alertHandler?(MalwareAlert(
                     path: path,

--- a/Sources/MacClean/Modules/Optimization/ProcessMonitorAdvanced.swift
+++ b/Sources/MacClean/Modules/Optimization/ProcessMonitorAdvanced.swift
@@ -75,22 +75,23 @@ public actor ProcessStatsCollector {
         return 0
     }
 
+    /// `task_for_pid` (the previous implementation here) requires the
+    /// `com.apple.security.get-task-allow` entitlement — or root — to
+    /// obtain another process's task port. Neither applies to a normal,
+    /// hardened-runtime GUI app querying sibling apps, so it failed with
+    /// KERN_FAILURE for essentially every process but our own, and every
+    /// app in the "heavy consumers" / memory list silently showed 0 bytes.
+    /// `proc_pid_rusage` goes through libproc instead (the same family of
+    /// call already used for `cpuUsage` above via `proc_pidinfo`), which
+    /// only needs to see the target process, not open its task port.
     private nonisolated func memoryUsage(for pid: Int32) -> UInt64 {
-        var taskInfo = mach_task_basic_info()
-        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size / MemoryLayout<natural_t>.size)
-
-        var task: mach_port_t = 0
-        let kr = task_for_pid(mach_task_self_, pid, &task)
-        guard kr == KERN_SUCCESS else { return 0 }
-        defer { mach_port_deallocate(mach_task_self_, task) }
-
-        let result = withUnsafeMutablePointer(to: &taskInfo) { ptr in
-            ptr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
-                task_info(task, task_flavor_t(MACH_TASK_BASIC_INFO), intPtr, &count)
+        var info = rusage_info_v2()
+        let result = withUnsafeMutablePointer(to: &info) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { rawPtr in
+                proc_pid_rusage(pid, RUSAGE_INFO_V2, rawPtr)
             }
         }
-
-        guard result == KERN_SUCCESS else { return 0 }
-        return UInt64(taskInfo.resident_size)
+        guard result == 0 else { return 0 }
+        return info.ri_resident_size
     }
 }

--- a/Sources/MacClean/Modules/SystemJunk/DeletedUsersScanner.swift
+++ b/Sources/MacClean/Modules/SystemJunk/DeletedUsersScanner.swift
@@ -17,13 +17,28 @@ public enum DeletedUsersScanner {
 
         let activeUsers = readActiveUsernames()
 
+        // `dscl` failing, being sandboxed away, or genuinely returning
+        // nothing is indistinguishable from "no active users" — and an
+        // empty `activeUsers` set would make `isResidualHomeFolder` say
+        // yes to EVERY folder under /Users, including the account that's
+        // running this scan right now. A real Mac always has at least one
+        // active user, so treat empty as "couldn't determine" and refuse
+        // to flag anything rather than risk offering someone's own home
+        // folder for deletion.
+        guard !activeUsers.isEmpty else { return [] }
+
+        // Defense in depth on top of the dscl-based check: never flag the
+        // account actually running this process, no matter what dscl said.
+        let currentUser = NSUserName()
+
         var results: [FileItem] = []
         for folder in userFolders {
             let values = try? folder.resourceValues(forKeys: [.isDirectoryKey])
             guard values?.isDirectory == true else { continue }
 
             let name = folder.lastPathComponent
-            guard DeletedUsersCategory.isResidualHomeFolder(name: name, activeUsers: activeUsers)
+            guard name != currentUser,
+                  DeletedUsersCategory.isResidualHomeFolder(name: name, activeUsers: activeUsers)
             else { continue }
 
             let size = directorySize(folder)

--- a/Sources/MacClean/Modules/SystemJunk/SystemJunkModule.swift
+++ b/Sources/MacClean/Modules/SystemJunk/SystemJunkModule.swift
@@ -47,7 +47,7 @@ public struct SystemJunkModule: ScanModule {
                     // .app bundles, shells out to lipo, asks the policy)
                     // rather than the targeted path enumerator.
                     if cat.scanCategory == .universalBinaries {
-                        let items = UniversalBinariesScanner.scan()
+                        let items = UniversalBinariesScanner.scanAllApplicationsDirectories()
                         guard !items.isEmpty else { return nil }
                         return ScanResult(
                             category: .universalBinaries,
@@ -62,6 +62,19 @@ public struct SystemJunkModule: ScanModule {
                         guard !items.isEmpty else { return nil }
                         return ScanResult(
                             category: .appLeftovers,
+                            items: items,
+                            autoSelect: cat.scanCategory.autoSelect
+                        )
+                    }
+                    // Deleted users: /Users folders that no longer match an
+                    // active account per `dscl`. Its own scanner (not
+                    // TargetedScanner) cross-checks against the live user
+                    // list rather than a static path target.
+                    if cat.scanCategory == .deletedUsers {
+                        let items = DeletedUsersScanner.scanForDeletedUserFolders()
+                        guard !items.isEmpty else { return nil }
+                        return ScanResult(
+                            category: .deletedUsers,
                             items: items,
                             autoSelect: cat.scanCategory.autoSelect
                         )

--- a/Sources/MacClean/Modules/SystemJunk/UniversalBinariesScanner.swift
+++ b/Sources/MacClean/Modules/SystemJunk/UniversalBinariesScanner.swift
@@ -43,6 +43,35 @@ public enum UniversalBinariesScanner {
         return results.compactMap { $0 }
     }
 
+    /// Scans every directory macOS actually installs `.app` bundles into —
+    /// `/Applications` AND the current user's `~/Applications` — and merges
+    /// the results. `scan(in:)` alone only ever covered the system-wide
+    /// folder; an app installed only under the user's own Applications
+    /// folder (a common outcome of a drag-install or a non-admin install)
+    /// was silently invisible to this scanner even though `AppDiscovery`
+    /// (the Uninstaller's app lister) has always covered both.
+    public static func scanAllApplicationsDirectories(
+        systemApplications: URL = URL(filePath: "/Applications"),
+        home: URL = MCConstants.home,
+        host: BundleHostInfo = .current,
+        policy: UniversalBinariesPolicy = UniversalBinariesPolicy()
+    ) -> [FileItem] {
+        let roots = [
+            systemApplications,
+            home.appending(path: "Applications"),
+        ]
+        var seen = Set<String>()
+        var results: [FileItem] = []
+        for root in roots {
+            for item in scan(in: root, host: host, policy: policy) {
+                let path = item.url.path(percentEncoded: false)
+                guard seen.insert(path).inserted else { continue }
+                results.append(item)
+            }
+        }
+        return results
+    }
+
     /// Gathers info for one bundle, asks the policy, and returns the
     /// associated `FileItem` (representing the whole .app to thin) if the
     /// policy says to thin.
@@ -75,8 +104,8 @@ public enum UniversalBinariesScanner {
         )
 
         // Use the main exec's archs as the canonical set for the policy
-        // decision. (Embedded frameworks/XPCs may have slightly different
-        // arch sets in pathological cases; for v1 we trust the main exec.)
+        // decision (SIP / Apple-system / App Store / arm64e checks are all
+        // path- or bundleID-driven and don't need anything more).
         let lipoArchs = runLipoInfo(at: executableURL)
         let archSet: Set<BinaryArch> = Set(lipoArchs.compactMap(BinaryArch.init(lipoName:)))
         guard !archSet.isEmpty else { return nil }
@@ -88,14 +117,57 @@ public enum UniversalBinariesScanner {
             architectures: archSet
         )
 
-        guard case .thin(_, let dropping) = policy.decideThinning(for: info, host: host) else {
+        let decision = policy.decideThinning(for: info, host: host)
+
+        let fatBinaries: [URL]
+        let dropping: Set<BinaryArch>
+        // Number of architecture slices the *fat binaries we're actually
+        // about to sum bytes for* carry — NOT necessarily `archSet.count`
+        // (the main exec's count), since the fallback branch below sums
+        // bytes across embedded binaries whose slice count can differ from
+        // the main exec's.
+        let originalArchCount: Int
+
+        switch decision {
+        case .thin(_, let d):
+            fatBinaries = MachOWalker.fatBinaries(in: appURL)
+            dropping = d
+            originalArchCount = archSet.count
+
+        case .skip(.alreadyThin):
+            // The main executable already runs natively on this Mac, but
+            // that says nothing about the rest of the bundle. Modern
+            // Apple-Silicon-native apps routinely ship a thin arm64 main
+            // exec alongside third-party frameworks (Sparkle, Electron/CEF
+            // helpers, ffmpeg, …) that were never rebuilt thin — those can
+            // be 10s to 100s of MB, and the old main-exec-only check
+            // skipped every one of these apps as "nothing to do" without
+            // ever looking. Walk the bundle for any OTHER fat Mach-O and
+            // only bail out for real if none exists.
+            let embeddedFat = MachOWalker.fatBinaries(in: appURL)
+                .filter { $0.standardizedFileURL != executableURL.standardizedFileURL }
+            var embeddedArchs: Set<BinaryArch> = []
+            for binary in embeddedFat {
+                embeddedArchs.formUnion(runLipoInfo(at: binary).compactMap(BinaryArch.init(lipoName:)))
+            }
+            let extraArchs = embeddedArchs.subtracting([host.hostArch])
+            guard !extraArchs.isEmpty else { return nil }
+            fatBinaries = embeddedFat
+            dropping = extraArchs
+            // Use the embedded binaries' own slice count (host + extras),
+            // not the main exec's (which is 1 here by definition of this
+            // branch) — otherwise the estimate divides by 1 and reports
+            // ~100% of the framework's fat size as "savings" instead of
+            // the actual ~1/N.
+            originalArchCount = embeddedArchs.count
+
+        default:
             return nil
         }
 
         // Sum sizes across every fat binary in the bundle for a meaningful
         // "you'll save X MB" estimate. Frameworks/XPC services often
         // contribute as much as the main exec.
-        let fatBinaries = MachOWalker.fatBinaries(in: appURL)
         let totalFatBytes = fatBinaries.reduce(UInt64(0)) { sum, url in
             let attrs = try? FileManager.default
                 .attributesOfItem(atPath: url.path(percentEncoded: false))
@@ -103,7 +175,7 @@ public enum UniversalBinariesScanner {
         }
         let savings = UniversalBinariesPolicy.estimatedSavings(
             originalSize: totalFatBytes,
-            originalArchCount: archSet.count,
+            originalArchCount: originalArchCount,
             droppingCount: dropping.count
         )
 

--- a/Sources/MacCleanKit/MalwareSignatures.swift
+++ b/Sources/MacCleanKit/MalwareSignatures.swift
@@ -32,7 +32,7 @@ public enum MalwareSignatures {
     /// Substrings that, when found inside a launch agent's `ProgramArguments`,
     /// indicate a likely malicious payload.
     public static let suspiciousLaunchAgentSubstrings: [String] = [
-        "/tmp/", "curl ", "python -c", "osascript",
+        "/tmp/", "curl ", "wget ", "python -c", "osascript", "base64",
     ]
 
     /// Returns true if `name` matches any known adware/malware pattern by name.

--- a/Sources/MacCleanKit/Models/ScanCategory.swift
+++ b/Sources/MacCleanKit/Models/ScanCategory.swift
@@ -141,7 +141,7 @@ public enum ScanCategory: String, CaseIterable, Identifiable, Sendable {
     public var autoSelect: Bool {
         switch self {
         case .unusedDiskImages, .largeFiles, .oldFiles, .duplicates,
-             .universalBinaries, .appLeftovers,
+             .universalBinaries, .appLeftovers, .deletedUsers,
              .packageManagerCaches, .ideCaches, .aiToolCaches:
             // appLeftovers: deletes another app's leftover data; detection is
             // conservative but never auto-checked — the user reviews first.
@@ -149,6 +149,11 @@ public enum ScanCategory: String, CaseIterable, Identifiable, Sendable {
             // place (lipo preserves their signatures; we never re-sign).
             // Still only reversible by re-downloading the app, so don't
             // pre-check — force explicit consent.
+            // deletedUsers: flags an entire /Users/<name> home folder based
+            // on it being absent from `dscl . -list /Users` at scan time —
+            // a network/mobile account that's briefly unreachable would
+            // look identical to a genuinely removed one. Never pre-check;
+            // the user must look at the name and confirm each one.
             false
         default:
             true

--- a/Tests/MacCleanTests/UniversalBinariesScannerTests.swift
+++ b/Tests/MacCleanTests/UniversalBinariesScannerTests.swift
@@ -62,6 +62,20 @@ final class UniversalBinariesScannerTests: XCTestCase {
         return appURL
     }
 
+    /// Adds a real fat Mach-O at `Contents/Frameworks/<frameworkName>` to an
+    /// already-created app bundle, simulating a third-party framework
+    /// (Sparkle, Electron/CEF, ffmpeg, …) that stayed universal even though
+    /// the app's own main executable is thin/native.
+    @discardableResult
+    private func embedFatFramework(
+        in appURL: URL,
+        named frameworkName: String = "Sparkle",
+        archs: [String] = ["x86_64", "arm64"]
+    ) throws -> Bool {
+        let binary = appURL.appending(path: "Contents/Frameworks/\(frameworkName)")
+        return try UniversalBinaryFixture.build(at: binary, architectures: archs)
+    }
+
     func testScanner_picksUpFatNonAppleApp() throws {
         let appURL = try makeFakeApp(name: "AcmeChat", bundleID: "com.acme.chat")
 
@@ -98,6 +112,84 @@ final class UniversalBinariesScannerTests: XCTestCase {
         _ = try makeFakeApp(name: "NativeOnly", bundleID: "com.example.native", archs: [onlyHost])
         let items = UniversalBinariesScanner.scan(in: root)
         XCTAssertTrue(items.isEmpty, "single-arch app already matches host — nothing to thin")
+    }
+
+    /// Regression test for the bug where eligibility was decided from the
+    /// main executable alone: an app whose main exec is already thin/native
+    /// but that still bundles a fat third-party framework (Sparkle,
+    /// Electron/CEF, ffmpeg, …) must still be offered for thinning — there's
+    /// real space to reclaim inside the framework even though the main exec
+    /// itself has nothing to do.
+    func testScanner_picksUpFatEmbeddedFrameworkEvenWhenMainExecIsThin() throws {
+        let onlyHost = BundleHostInfo.current.hostArch.lipoName
+        let appURL = try makeFakeApp(
+            name: "ThinMainFatFramework", bundleID: "com.example.thinmain", archs: [onlyHost]
+        )
+        let embedded = try embedFatFramework(in: appURL)
+        try XCTSkipUnless(embedded, "cc not available")
+
+        let items = UniversalBinariesScanner.scan(in: root)
+        XCTAssertEqual(
+            items.count, 1,
+            "app must still be offered: its embedded framework is fat even though the main exec is thin"
+        )
+        XCTAssertGreaterThan(items[0].size, 0, "estimated savings must reflect the fat framework")
+    }
+
+    /// A genuinely fully-thin app (main exec AND every embedded binary
+    /// single-arch) has nothing to reclaim anywhere and must stay skipped.
+    func testScanner_skipsAppWithNoFatBinariesAnywhere() throws {
+        let onlyHost = BundleHostInfo.current.hostArch.lipoName
+        let appURL = try makeFakeApp(
+            name: "FullyThin", bundleID: "com.example.fullythin", archs: [onlyHost]
+        )
+        try XCTSkipUnless(
+            try embedFatFramework(in: appURL, archs: [onlyHost]),
+            "cc not available"
+        )
+        let items = UniversalBinariesScanner.scan(in: root)
+        XCTAssertTrue(items.isEmpty, "nothing anywhere in the bundle is fat — nothing to thin")
+    }
+
+    /// Regression test: the scanner used to only look at `/Applications`,
+    /// silently missing every app installed under `~/Applications`.
+    func testScanAllApplicationsDirectories_mergesSystemAndUserApplications() throws {
+        let systemApplications = root.appending(path: "Applications")
+        let userHome = root.appending(path: "Home")
+        let userApplications = userHome.appending(path: "Applications")
+        try FileManager.default.createDirectory(at: systemApplications, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: userApplications, withIntermediateDirectories: true)
+
+        // Build directly into each root instead of reusing makeFakeApp
+        // (which always targets `root` itself).
+        func makeApp(in dir: URL, name: String, bundleID: String) throws {
+            let appURL = dir.appending(path: "\(name).app")
+            let macOS = appURL.appending(path: "Contents/MacOS")
+            try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+            let exec = macOS.appending(path: name)
+            let built = try UniversalBinaryFixture.build(at: exec, architectures: ["x86_64", "arm64"])
+            try XCTSkipUnless(built, "cc not available")
+            let plist: [String: Any] = [
+                "CFBundleIdentifier": bundleID, "CFBundleExecutable": name,
+                "CFBundleName": name, "CFBundleVersion": "1",
+                "CFBundleShortVersionString": "1.0", "CFBundlePackageType": "APPL",
+            ]
+            let plistData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+            try plistData.write(to: appURL.appending(path: "Contents/Info.plist"))
+        }
+
+        try makeApp(in: systemApplications, name: "SystemWideApp", bundleID: "com.acme.systemwide")
+        try makeApp(in: userApplications, name: "UserOnlyApp", bundleID: "com.acme.useronly")
+
+        let items = UniversalBinariesScanner.scanAllApplicationsDirectories(
+            systemApplications: systemApplications,
+            home: userHome
+        )
+        let names = Set(items.map { $0.url.lastPathComponent })
+        XCTAssertEqual(
+            names, ["SystemWideApp.app", "UserOnlyApp.app"],
+            "both the system-wide and the per-user Applications folder must be scanned"
+        )
     }
 
     /// End-to-end: scan a synthetic app, take its FileItem, hand to


### PR DESCRIPTION
- UniversalBinariesScanner: eligibility was decided from the main
  executable's architecture set alone. Apps that ship a thin/native main
  exec alongside fat third-party frameworks (Sparkle, Electron/CEF,
  ffmpeg, ...) were silently skipped as "already thin" even though the
  frameworks were still fully universal. Now falls back to walking the
  whole bundle for other fat Mach-O binaries when the main exec alone
  is already native, and adjusts the savings estimate accordingly.
- UniversalBinariesScanner: also scan ~/Applications, not just
  /Applications (matches AppDiscovery, used by the Uninstaller).
- Wire up DeletedUsersScanner into SystemJunkModule (it was never
  called from anywhere -- the "Deleted Users" category always returned
  zero results). Hardened at the same time: refuses to flag anything
  if `dscl` returns no active users (would otherwise treat every
  /Users folder, including the current user's own, as "deleted"), and
  never flags the currently running user regardless of what dscl says.
  Also added to the non-auto-selected categories, consistent with
  other categories that can affect more than obviously-safe caches.
- RealTimeMalwareMonitor kept its own hand-duplicated copy of the
  malware-signature and suspicious-launch-agent pattern lists, which
  had drifted out of sync with MacCleanKit.MalwareSignatures (missing
  several known adware families). Now sources both lists directly from
  MalwareSignatures so the on-demand scan and the real-time monitor
  can no longer disagree.
- ProcessStatsCollector.memoryUsage used task_for_pid, which is denied
  by the OS for any process other than the caller's own on a normal
  hardened-runtime build without a debug entitlement -- so per-app
  memory always read back as 0 bytes. Switched to proc_pid_rusage
  (RUSAGE_INFO_V2), which doesn't need a task port.

Tests: added scanner-level regression coverage for the embedded-fat-
framework case, the fully-thin no-op case, and the ~/Applications
merge. Full suite: 764 tests, 0 failures (swift test).
