### PR TITLE
Fix #138: keep the menu-bar helper from vanishing

### DIFF
--- a/Sources/MacClean/App/MacCleanApp.swift
+++ b/Sources/MacClean/App/MacCleanApp.swift
@@ -112,6 +112,7 @@ struct MacCleanApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppearanceManager.applyStored()
+        MenuBarLauncher.shared.startWatchingHelperTermination()
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/Sources/MacClean/Services/MenuBarLauncher.swift
+++ b/Sources/MacClean/Services/MenuBarLauncher.swift
@@ -10,10 +10,11 @@ import MacCleanKit
 /// looks at that exact path to find the helper, so the bundling in
 /// `scripts/build-dmg.sh` must match.
 ///
-/// On registration the system launches the helper immediately (no need
-/// to call NSWorkspace.open). On unregister the helper is also stopped.
-/// State is queryable via `status` so the Settings toggle can reflect
-/// the truth of "is the widget actually running right now."
+/// On registration the system *may* launch the helper; with ad-hoc signed
+/// builds it often does not. `setEnabled(true)` therefore waits a short
+/// grace and opens via NSWorkspace if the helper is still missing. On
+/// unregister the helper is stopped. A terminate observer relaunches it
+/// if the Settings toggle is still on and the user did not quit the extra.
 @MainActor
 @Observable
 public final class MenuBarLauncher {
@@ -48,6 +49,8 @@ public final class MenuBarLauncher {
     public internal(set) var statusSnapshot: SMAppService.Status = .notRegistered
 
     private let service = SMAppService.loginItem(identifier: MCConstants.menuBundleIdentifier)
+    private var helperTerminationObserver: NSObjectProtocol?
+    private var isLaunchingHelper = false
 
     public var isRegistered: Bool {
         service.status == .enabled
@@ -59,6 +62,41 @@ public final class MenuBarLauncher {
 
     private init() {
         statusSnapshot = service.status
+        startWatchingHelperTermination()
+    }
+
+    /// Relaunch the helper if it dies unexpectedly while the Settings toggle
+    /// is on. Idempotent. The observer hops onto the main actor with
+    /// `Task { @MainActor in }` — do not replace that with a completion
+    /// handler that touches `@MainActor` state (issue #58).
+    public func startWatchingHelperTermination() {
+        guard helperTerminationObserver == nil else { return }
+        helperTerminationObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard
+                let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+                app.bundleIdentifier == MCConstants.menuBundleIdentifier
+            else { return }
+            Task { @MainActor in
+                await MenuBarLauncher.shared.ensureHelperRunningIfPreferred()
+            }
+        }
+    }
+
+    /// Watchdog entry: launch the helper if the preference is on, it is not
+    /// running, and the user did not quit it from the extra. Does **not**
+    /// call `SMAppService.register()` — that stays on the enable path so a
+    /// crash cannot spam backgroundtaskmanagementd.
+    public func ensureHelperRunningIfPreferred() async {
+        let enabled = UserDefaults.standard.object(forKey: MenuBarKeepAlive.preferenceKey) as? Bool ?? true
+        await reconcileHelper(
+            preferenceEnabled: enabled,
+            afterRegister: false,
+            honorUserQuit: true
+        )
     }
 
     public func register() throws {
@@ -127,10 +165,13 @@ public final class MenuBarLauncher {
             enabled ? .registrationFailed($0) : .unregisterFailed($0)
         }
         if enabled {
-            launchHelperIfNotRunning()
-        } else {
-            terminateRunningHelper()
+            MenuBarKeepAlive.setUserQuit(false, defaults: SharedAppState.defaults)
         }
+        await reconcileHelper(
+            preferenceEnabled: enabled,
+            afterRegister: enabled,
+            honorUserQuit: false
+        )
         statusSnapshot = service.status
         // Pad sub-minimum operations so the spinner doesn't flash for a
         // single frame (see minimumBusyDuration).
@@ -160,9 +201,41 @@ public final class MenuBarLauncher {
         }
     }
 
-    private func launchHelperIfNotRunning() {
-        guard !isHelperRunning(), let url = helperAppURL() else { return }
-        Task { @MainActor in await openHelper(at: url) }
+    /// Align the running helper with the preference. `afterRegister` waits
+    /// once so SMAppService can spawn before we open a second copy.
+    /// `honorUserQuit` is true for the watchdog (don't undo Quit Monitor)
+    /// and false for the Settings toggle / launch re-sync.
+    func reconcileHelper(
+        preferenceEnabled: Bool,
+        afterRegister: Bool,
+        honorUserQuit: Bool
+    ) async {
+        var waited = !afterRegister
+        let userQuit = honorUserQuit && MenuBarKeepAlive.isUserQuit(SharedAppState.defaults)
+        while true {
+            switch MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: preferenceEnabled,
+                helperIsRunning: isHelperRunning(),
+                userQuit: userQuit,
+                alreadyWaitedAfterRegister: waited,
+                launchInFlight: isLaunchingHelper
+            ) {
+            case .none:
+                return
+            case .waitThenRecheck:
+                try? await Task.sleep(for: MenuBarKeepAlivePolicy.smAppServiceLaunchGrace)
+                waited = true
+            case .launch:
+                guard let url = helperAppURL() else { return }
+                isLaunchingHelper = true
+                defer { isLaunchingHelper = false }
+                await openHelper(at: url)
+                return
+            case .terminate:
+                terminateRunningHelper()
+                return
+            }
+        }
     }
 
     /// Launch the bundled helper at `url`, recording any failure in `lastError`.

--- a/Sources/MacCleanKit/MenuBarHelperPolicy.swift
+++ b/Sources/MacCleanKit/MenuBarHelperPolicy.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Snapshot of one `com.macclean.menu` process for duplicate arbitration.
+public struct MenuBarInstance: Equatable, Sendable {
+    public let pid: Int32
+    public let launchDate: Date?
+
+    public init(pid: Int32, launchDate: Date?) {
+        self.pid = pid
+        self.launchDate = launchDate
+    }
+}
+
+/// Decides whether this helper process should exit because another copy is
+/// already running.
+///
+/// The previous check was `if any sibling { exit(0) }`. When SMAppService and
+/// NSWorkspace both launched a copy, both processes saw each other and both
+/// exited — the menu-bar extra vanished (issue #138). The rule here is a total
+/// order: oldest `launchDate` wins, then lowest PID, so exactly one survivor.
+public enum MenuBarInstancePolicy {
+    public static func shouldExitAsDuplicate(
+        selfPID: Int32,
+        selfLaunchDate: Date?,
+        siblings: [MenuBarInstance]
+    ) -> Bool {
+        guard !siblings.isEmpty else { return false }
+        let selfInstance = MenuBarInstance(pid: selfPID, launchDate: selfLaunchDate)
+        let keeper = (siblings + [selfInstance]).min { rank($0) < rank($1) }
+        return keeper?.pid != selfPID
+    }
+
+    /// Missing launch dates sort as distant future so a process whose
+    /// `launchDate` is known (already running) beats one LaunchServices has
+    /// not populated yet. Two unknowns fall through to lowest PID. The pair
+    /// stays a total order, so exactly one keeper.
+    private static func rank(_ instance: MenuBarInstance) -> (Date, Int32) {
+        (instance.launchDate ?? .distantFuture, instance.pid)
+    }
+}
+
+/// Shared-suite flag so an explicit **Quit Monitor** is not undone by the
+/// main app's terminate observer. Injected `UserDefaults` keeps tests off
+/// the real `com.macclean.shared` plist.
+public enum MenuBarKeepAlive {
+    public static let userQuitKey = "menuBarWidgetUserQuit"
+    public static let preferenceKey = "showMenuBarWidget"
+
+    public static func isUserQuit(_ defaults: UserDefaults) -> Bool {
+        defaults.bool(forKey: userQuitKey)
+    }
+
+    public static func setUserQuit(_ value: Bool, defaults: UserDefaults) {
+        defaults.set(value, forKey: userQuitKey)
+    }
+}
+
+/// What the main app should do to keep the helper aligned with the Settings
+/// toggle. Pure: no `NSWorkspace` / `SMAppService`.
+public enum MenuBarKeepAlivePolicy {
+    public enum Action: Equatable, Sendable {
+        case none
+        case waitThenRecheck
+        case launch
+        case terminate
+    }
+
+    /// Grace so `SMAppService.register()` can spawn the helper before we
+    /// `NSWorkspace.open` a second copy (the race that used to mutual-exit).
+    public static let smAppServiceLaunchGrace: Duration = .milliseconds(500)
+
+    public static func action(
+        preferenceEnabled: Bool,
+        helperIsRunning: Bool,
+        userQuit: Bool,
+        alreadyWaitedAfterRegister: Bool,
+        launchInFlight: Bool
+    ) -> Action {
+        if !preferenceEnabled {
+            return helperIsRunning ? .terminate : .none
+        }
+        if helperIsRunning || userQuit || launchInFlight {
+            return .none
+        }
+        if !alreadyWaitedAfterRegister {
+            return .waitThenRecheck
+        }
+        return .launch
+    }
+}

--- a/Sources/MacCleanMenu/MacCleanMenuApp.swift
+++ b/Sources/MacCleanMenu/MacCleanMenuApp.swift
@@ -8,19 +8,32 @@ struct MacCleanMenuApp: App {
         AppLanguage.registerDefault(.system)
         // Single-instance enforcement. macOS does NOT auto-deduplicate
         // LSUIElement apps by bundle id the way it does for regular apps,
-        // and we have two launch paths (SMAppService + NSWorkspace). If a
-        // sibling instance is already running, terminate self immediately
-        // so the user never sees two icons in the menu bar.
+        // and we have two launch paths (SMAppService + NSWorkspace). Keep
+        // the oldest copy; never `exit(0)` from every sibling — that took
+        // the extra down when both copies started at once (issue #138).
         // Only enforce when we have a real bundle id (i.e. running from
         // the .app). Under `swift run` the bare executable has no bundle
         // id, and matching against other nil-bundle processes would make
         // the dev build exit immediately.
         if let myBundleID = Bundle.main.bundleIdentifier {
             let myPID = ProcessInfo.processInfo.processIdentifier
-            let duplicate = NSWorkspace.shared.runningApplications.contains {
-                $0.bundleIdentifier == myBundleID && $0.processIdentifier != myPID
+            let running = NSWorkspace.shared.runningApplications
+            let me = running.first { $0.processIdentifier == myPID }
+            let siblings = running.compactMap { app -> MenuBarInstance? in
+                guard app.bundleIdentifier == myBundleID,
+                      app.processIdentifier != myPID else { return nil }
+                return MenuBarInstance(pid: app.processIdentifier, launchDate: app.launchDate)
             }
-            if duplicate { exit(0) }
+            // Keep-one, never both-exit. The old any-sibling check killed
+            // every copy when SMAppService and NSWorkspace raced
+            // (issue #138).
+            if MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: myPID,
+                selfLaunchDate: me?.launchDate,
+                siblings: siblings
+            ) {
+                exit(0)
+            }
         }
     }
 
@@ -346,7 +359,10 @@ struct MenuContentView: View {
 
     private var footer: some View {
         HStack(spacing: 8) {
-            Button { NSApplication.shared.terminate(nil) } label: {
+            Button {
+                MenuBarKeepAlive.setUserQuit(true, defaults: SharedAppState.defaults)
+                NSApplication.shared.terminate(nil)
+            } label: {
                 Image(systemName: "power").font(.system(size: 12, weight: .bold)).foregroundStyle(.white)
                     .frame(width: 34, height: 32)
                     .background(MenuPalette.red, in: RoundedRectangle(cornerRadius: 9, style: .continuous))

--- a/Tests/MacCleanKitTests/MenuBarHelperPolicyTests.swift
+++ b/Tests/MacCleanKitTests/MenuBarHelperPolicyTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import MacCleanKit
+
+final class MenuBarHelperPolicyTests: XCTestCase {
+
+    // MARK: - Duplicate keep-one (issue #138)
+
+    func testLoneInstanceDoesNotExit() {
+        XCTAssertFalse(
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: 42,
+                selfLaunchDate: Date(timeIntervalSince1970: 100),
+                siblings: []
+            )
+        )
+    }
+
+    func testTwoInstancesRacingNeverBothExit() {
+        let a = MenuBarInstance(pid: 100, launchDate: Date(timeIntervalSince1970: 1))
+        let b = MenuBarInstance(pid: 200, launchDate: Date(timeIntervalSince1970: 1.05))
+        let aExits = MenuBarInstancePolicy.shouldExitAsDuplicate(
+            selfPID: a.pid, selfLaunchDate: a.launchDate, siblings: [b]
+        )
+        let bExits = MenuBarInstancePolicy.shouldExitAsDuplicate(
+            selfPID: b.pid, selfLaunchDate: b.launchDate, siblings: [a]
+        )
+        XCTAssertNotEqual(aExits, bExits, "exactly one of the two copies must stay")
+        XCTAssertTrue(aExits || bExits)
+        XCTAssertFalse(aExits, "older launchDate must be the survivor")
+    }
+
+    func testEqualLaunchDatesKeepLowestPID() {
+        let date = Date(timeIntervalSince1970: 50)
+        XCTAssertFalse(
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: 10, selfLaunchDate: date,
+                siblings: [MenuBarInstance(pid: 20, launchDate: date)]
+            )
+        )
+        XCTAssertTrue(
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: 20, selfLaunchDate: date,
+                siblings: [MenuBarInstance(pid: 10, launchDate: date)]
+            )
+        )
+    }
+
+    func testThreeInstancesKeepExactlyOne() {
+        let instances = [
+            MenuBarInstance(pid: 3, launchDate: Date(timeIntervalSince1970: 30)),
+            MenuBarInstance(pid: 1, launchDate: Date(timeIntervalSince1970: 10)),
+            MenuBarInstance(pid: 2, launchDate: Date(timeIntervalSince1970: 20)),
+        ]
+        let exits = instances.map { me in
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: me.pid,
+                selfLaunchDate: me.launchDate,
+                siblings: instances.filter { $0.pid != me.pid }
+            )
+        }
+        XCTAssertEqual(exits.filter { $0 }.count, 2)
+        XCTAssertFalse(exits[1], "pid 1 has the oldest launchDate")
+    }
+
+    func testMissingLaunchDateFallsBackToLowestPID() {
+        XCTAssertFalse(
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: 5, selfLaunchDate: nil,
+                siblings: [MenuBarInstance(pid: 9, launchDate: nil)]
+            )
+        )
+        XCTAssertTrue(
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: 9, selfLaunchDate: nil,
+                siblings: [MenuBarInstance(pid: 5, launchDate: nil)]
+            )
+        )
+    }
+
+    func testKnownLaunchDateBeatsMissingDate() {
+        let dated = Date(timeIntervalSince1970: 100)
+        XCTAssertFalse(
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: 1, selfLaunchDate: dated,
+                siblings: [MenuBarInstance(pid: 2, launchDate: nil)]
+            )
+        )
+        XCTAssertTrue(
+            MenuBarInstancePolicy.shouldExitAsDuplicate(
+                selfPID: 2, selfLaunchDate: nil,
+                siblings: [MenuBarInstance(pid: 1, launchDate: dated)]
+            )
+        )
+    }
+
+    // MARK: - Keep-alive
+
+    func testDisableTerminatesARunningHelper() {
+        XCTAssertEqual(
+            MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: false,
+                helperIsRunning: true,
+                userQuit: false,
+                alreadyWaitedAfterRegister: true,
+                launchInFlight: false
+            ),
+            .terminate
+        )
+    }
+
+    func testDisableDoesNothingWhenAlreadyStopped() {
+        XCTAssertEqual(
+            MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: false,
+                helperIsRunning: false,
+                userQuit: false,
+                alreadyWaitedAfterRegister: true,
+                launchInFlight: false
+            ),
+            .none
+        )
+    }
+
+    func testEnableWaitsOnceAfterRegisterBeforeOpening() {
+        XCTAssertEqual(
+            MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: true,
+                helperIsRunning: false,
+                userQuit: false,
+                alreadyWaitedAfterRegister: false,
+                launchInFlight: false
+            ),
+            .waitThenRecheck
+        )
+    }
+
+    func testEnableLaunchesAfterGraceIfStillMissing() {
+        XCTAssertEqual(
+            MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: true,
+                helperIsRunning: false,
+                userQuit: false,
+                alreadyWaitedAfterRegister: true,
+                launchInFlight: false
+            ),
+            .launch
+        )
+    }
+
+    func testEnableDoesNothingWhenHelperAlreadyRunning() {
+        XCTAssertEqual(
+            MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: true,
+                helperIsRunning: true,
+                userQuit: false,
+                alreadyWaitedAfterRegister: false,
+                launchInFlight: false
+            ),
+            .none
+        )
+    }
+
+    func testUserQuitDoesNotRelaunchWhileToggleStaysOn() {
+        XCTAssertEqual(
+            MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: true,
+                helperIsRunning: false,
+                userQuit: true,
+                alreadyWaitedAfterRegister: true,
+                launchInFlight: false
+            ),
+            .none
+        )
+    }
+
+    func testLaunchInFlightPreventsASecondOpen() {
+        XCTAssertEqual(
+            MenuBarKeepAlivePolicy.action(
+                preferenceEnabled: true,
+                helperIsRunning: false,
+                userQuit: false,
+                alreadyWaitedAfterRegister: true,
+                launchInFlight: true
+            ),
+            .none
+        )
+    }
+
+    func testUserQuitFlagRoundTripsThroughInjectedDefaults() {
+        let suite = "menu-bar-keep-alive-test-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            return XCTFail("could not open isolated defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertFalse(MenuBarKeepAlive.isUserQuit(defaults))
+        MenuBarKeepAlive.setUserQuit(true, defaults: defaults)
+        XCTAssertTrue(MenuBarKeepAlive.isUserQuit(defaults))
+        MenuBarKeepAlive.setUserQuit(false, defaults: defaults)
+        XCTAssertFalse(MenuBarKeepAlive.isUserQuit(defaults))
+    }
+
+    func testSharedKeysStayStable() {
+        XCTAssertEqual(MenuBarKeepAlive.preferenceKey, "showMenuBarWidget")
+        XCTAssertEqual(MenuBarKeepAlive.userQuitKey, "menuBarWidgetUserQuit")
+    }
+}

--- a/Tests/MacCleanTests/MenuBarLauncherTests.swift
+++ b/Tests/MacCleanTests/MenuBarLauncherTests.swift
@@ -10,7 +10,8 @@ import MacCleanKit
 /// plant a login item on every test run. See the comparable LaunchAgent
 /// guidance: tests must not pollute the user's macOS state. The surface
 /// we can safely exercise is the read-only side: identity, initial
-/// state, status readability.
+/// state, status readability, plus source guards for the #138 keep-alive
+/// wiring. Decision logic lives in `MenuBarHelperPolicyTests`.
 @MainActor
 final class MenuBarLauncherTests: XCTestCase {
 
@@ -80,5 +81,53 @@ final class MenuBarLauncherTests: XCTestCase {
         // Reaching this line at all proves we survived the off-main hop.
         XCTAssertNotNil(launcher.lastError,
                         "A failed helper launch should surface via lastError")
+    }
+
+    func testHelperUsesKeepOneInstancePolicyNotMutualExit() throws {
+        let src = try String(contentsOf: sourceURL("Sources/MacCleanMenu/MacCleanMenuApp.swift"), encoding: .utf8)
+        XCTAssertTrue(
+            src.contains("MenuBarInstancePolicy.shouldExitAsDuplicate"),
+            "Helper must keep exactly one instance (issue #138), not exit whenever any sibling exists"
+        )
+        XCTAssertFalse(
+            src.contains("let duplicate = NSWorkspace"),
+            "The mutual-exit check must not come back"
+        )
+    }
+
+    func testQuitMonitorSetsSharedUserQuitFlag() throws {
+        let src = try String(contentsOf: sourceURL("Sources/MacCleanMenu/MacCleanMenuApp.swift"), encoding: .utf8)
+        XCTAssertTrue(
+            src.contains("MenuBarKeepAlive.setUserQuit(true"),
+            "Quit Monitor must set the shared user-quit flag so the watchdog does not immediately relaunch"
+        )
+    }
+
+    func testLauncherReconcilesThroughKeepAlivePolicy() throws {
+        let src = try String(contentsOf: sourceURL("Sources/MacClean/Services/MenuBarLauncher.swift"), encoding: .utf8)
+        XCTAssertTrue(src.contains("MenuBarKeepAlivePolicy.action"))
+        XCTAssertTrue(src.contains("didTerminateApplicationNotification"))
+        XCTAssertTrue(
+            src.contains("Task { @MainActor in"),
+            "Terminate observer must hop to the main actor; do not reintroduce an off-main completion handler (issue #58)"
+        )
+        XCTAssertTrue(src.contains("ensureHelperRunningIfPreferred"))
+        XCTAssertFalse(
+            src.contains("launchHelperIfNotRunning"),
+            "Direct open-without-wait must not race SMAppService"
+        )
+        let appSrc = try String(contentsOf: sourceURL("Sources/MacClean/App/MacCleanApp.swift"), encoding: .utf8)
+        XCTAssertTrue(
+            appSrc.contains("startWatchingHelperTermination"),
+            "Main app must start the helper-termination watchdog at launch"
+        )
+    }
+
+    private func sourceURL(_ relative: String) -> URL {
+        URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: relative)
     }
 }

--- a/docs/superpowers/plans/2026-08-26-menu-bar-widget-persist.md
+++ b/docs/superpowers/plans/2026-08-26-menu-bar-widget-persist.md
@@ -1,0 +1,38 @@
+# Menu-bar widget persist (#138) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the menu-bar helper from vanishing: keep-one-instance on duplicate launch, relaunch after unexpected exit while the toggle is on.
+
+**Architecture:** Pure `MenuBarInstancePolicy` + `MenuBarKeepAlivePolicy` in MacCleanKit. `MenuBarLauncher` and `MacCleanMenuApp` stay thin I/O wrappers. Shared defaults flag for user-quit.
+
+**Tech Stack:** Swift 6, AppKit, SMAppService, XCTest
+
+## Global Constraints
+
+- One feature per PR (CONTRIBUTING).
+- Business logic in MacCleanKit; I/O stays in MacClean / MacCleanMenu.
+- Do not call `SMAppService.register` / `unregister` from tests.
+- Do not reintroduce a completion-handler `openApplication` (issue #58).
+- Do not put `password` / `secret` / `api_key` / `token` in `Sources/`.
+- Honest scope: no Control Center overflow claim; no #137 process-memory mix-in.
+
+## Files
+
+| File | Role |
+|---|---|
+| `Sources/MacCleanKit/MenuBarHelperPolicy.swift` | Duplicate keep-one + keep-alive actions + user-quit key |
+| `Sources/MacClean/Services/MenuBarLauncher.swift` | Wait-then-open, terminate observer, clear user-quit on enable |
+| `Sources/MacClean/App/MacCleanApp.swift` | Start watching on launch |
+| `Sources/MacCleanMenu/MacCleanMenuApp.swift` | Policy-based duplicate exit; Quit sets user-quit |
+| `Tests/MacCleanKitTests/MenuBarHelperPolicyTests.swift` | Policy unit tests |
+| `Tests/MacCleanTests/MenuBarLauncherTests.swift` | Source guards + existing #58 path |
+
+## Tasks
+
+- [x] RED: MenuBarHelperPolicyTests
+- [x] GREEN: MenuBarHelperPolicy
+- [x] RED: launcher / helper source guards
+- [x] GREEN: wire launcher, helper, AppDelegate, Quit
+- [x] `swift test` full suite + CI secrets grep (779 passed, 3 skipped, 0 failures)
+- [ ] PR Fixes #138

--- a/docs/superpowers/specs/2026-08-26-menu-bar-widget-persist-design.md
+++ b/docs/superpowers/specs/2026-08-26-menu-bar-widget-persist-design.md
@@ -1,0 +1,78 @@
+# Menu-bar widget persist (#138)
+
+Date: 2026-08-26
+Status: Design (approved for implementation)
+
+## Problem
+
+Issue #138: on Sonoma 14.8.9 / Intel MacBook Air, after setting the extra to
+RAM usage, the menu-bar widget disappears and stays gone.
+
+The RAM metric itself does not hide the icon. `MacCleanMenuApp` always renders
+the sparkles template image; `MenuBarMetric.memoryUsage` only changes the
+adjacent text (`RAM N%` or `RAM --`). A missing extra means the **helper
+process is not running** (or macOS hid it in Control Center overflow — which
+this PR cannot fix).
+
+Two code-level failure modes, both already present:
+
+1. **Mutual `exit(0)`.** The helper has two launch paths (`SMAppService.register`
+   plus `NSWorkspace.openApplication`). `isHelperRunning()` can be false while
+   LaunchServices is still spawning the SMAppService copy, so a second copy
+   starts. Each `init` does `if any sibling { exit(0) }`. When both copies
+   become visible to `NSWorkspace` at the same time, **both** exit. Intel
+   machines widen that window. After that, nothing relaunches the helper until
+   the next login or a main-app window appear that happens to start only one copy.
+
+2. **No keep-alive.** If the helper crashes, `SMAppService.loginItem` does not
+   restart it. The main app only re-registers on window `onAppear`. There is no
+   `didTerminateApplication` observer.
+
+## Goal
+
+Keep exactly one `com.macclean.menu` process alive while the Settings toggle is
+on, without fighting an explicit Quit from the extra, and without promising
+that macOS will not hide extras in Control Center overflow.
+
+## Non-goals
+
+- Do not claim to fix Control Center / menu-bar overflow hiding.
+- Do not change `MenuBarMetric` or RAM collection (`host_statistics64`).
+- Do not mix in #137 (`task_for_pid` / process list memory).
+- Do not add a LaunchAgent `KeepAlive` plist (new launch mechanism).
+- Do not relaunch the helper when the main app is not running.
+- Do not call `register()` / `unregister()` from unit tests.
+
+## Approach
+
+Pure policy in `MacCleanKit`:
+
+- `MenuBarInstancePolicy.shouldExitAsDuplicate` — keep the oldest launchDate
+  (then lowest PID). Exactly one survivor; never both-exit.
+- `MenuBarKeepAlivePolicy.action` — enable + not running + not user-quit →
+  wait once after register (so SMAppService can spawn), then
+  `NSWorkspace.open`; disable → terminate; user-quit → do not relaunch.
+
+Thin wiring:
+
+- Helper `init` uses the instance policy instead of “any sibling → exit”.
+- Extra **Quit Monitor** sets `menuBarWidgetUserQuit` in the shared defaults
+  suite, then terminates.
+- `setEnabled(true)` clears that flag (toggle / main-app launch still restore
+  the extra, same as today).
+- `MenuBarLauncher` waits a short grace after `register()` before opening.
+- Main app observes `NSWorkspace.didTerminateApplicationNotification` for
+  `com.macclean.menu` and relaunches only when the policy says so. Hop onto
+  the main actor with `Task { @MainActor in }` (issue #58: never a
+  completion handler that touches `@MainActor` state off-main).
+
+## Honest product copy
+
+PR and comments must say: if macOS hid the extra in Control Center overflow,
+drag it back — this change does not control that. We fix the helper dying.
+
+## Testing
+
+Kit unit tests for both policies (two-process race, three instances, user-quit,
+wait-then-launch, launch-in-flight). Source guards that the helper calls the
+policy and that Quit sets the shared flag. No live `SMAppService` in tests.


### PR DESCRIPTION
## Summary
The menu-bar extra disappearing is the helper process going away, not the RAM metric hiding the sparkles. `MacCleanMenuApp` always draws the icon; `MenuBarMetric.memoryUsage` only changes the adjacent text (`RAM N%` or `RAM --`).

Two existing launch paths (`SMAppService.register` and `NSWorkspace.openApplication`) can start two copies. The helper then did `if any sibling { exit(0) }`. When both copies became visible at once — a wider window on Intel — **both** exited, and nothing relaunched them until the next login or a lucky main-app open.

This PR keeps exactly one instance, waits before a second open so SMAppService can spawn, and relaunches if the helper dies unexpectedly while the Settings toggle is still on.

**Not claimed:** macOS hiding extras in Control Center overflow. Drag the extra back there if that is what happened. This change does not control that.

**Not in this PR:** process-list memory (`task_for_pid`, issue #137). Different process, different bug.

Design: `docs/superpowers/specs/2026-08-26-menu-bar-widget-persist-design.md`.

## Changes
- `MenuBarInstancePolicy` — oldest `launchDate` (then lowest PID) survives; two racing copies never both exit
- `MenuBarKeepAlivePolicy` — wait once after register, then open; skip relaunch if the user quit the extra; skip a second open while one is in flight
- Helper **Quit Monitor** sets `menuBarWidgetUserQuit` in the shared defaults suite so the watchdog does not immediately undo it
- `setEnabled(true)` / main-app launch still clear that flag (opening Mac Sai restores the extra, same as today)
- Terminate observer hops with `Task { @MainActor in }` — does not reintroduce the issue #58 completion-handler SIGTRAP
- Watchdog does **not** call `SMAppService.register()` (enable path only)

## Test Plan
- [x] `swift test` — **779 passed**, 3 skipped, **0 failures** (`DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`)
- [x] `MenuBarHelperPolicyTests` — two-copy race never both-exit; three instances keep one; user-quit does not relaunch; wait-then-launch; launch-in-flight; injected defaults (no live `SMAppService`)
- [x] Source guards — helper calls `shouldExitAsDuplicate`; Quit sets the shared flag; launcher uses the policy + terminate observer; AppDelegate starts the watchdog
- [x] Issue #58 path still records `lastError` without trapping
- [x] CI secrets grep on `Sources/*.swift` — clean
- [ ] In the running app (Intel/Sonoma if possible): toggle extra on, confirm one icon; Quit Monitor stays gone until Mac Sai is opened again; kill `com.macclean.menu` while the main app is open and the extra comes back

## Checklist
- [x] Code compiles (`swift test`)
- [x] Follows existing style (Swift 6, policy in Kit, I/O in the app)
- [x] No telemetry or extra network calls
- [x] PR is focused (one fix: #138)
- [x] Does not promise Control Center overflow behaviour macOS owns

Fixes #138