### PR TITLE
Fix #7: show a tooltip on junk category headers

### DIFF
--- a/Sources/MacClean/Views/Shared/FileTableView.swift
+++ b/Sources/MacClean/Views/Shared/FileTableView.swift
@@ -289,6 +289,9 @@ private final class HeaderCellView: NSTableCellView {
         )
         title.stringValue = header.category.displayName
         subtitle.stringValue = header.category.subtitle
+        // Both labels truncate to one line, so a narrow window can hide what a
+        // category actually contains. Hovering the header row shows both in full.
+        toolTip = header.category.tooltip
         count.stringValue = L10n.tr("已选择 \(header.selectedCount)/\(header.fileCount)", "\(header.selectedCount)/\(header.fileCount) selected", "Выбрано \(header.selectedCount) из \(header.fileCount)")
         size.attributedStringValue = Self.sizeText(
             selected: header.selectedSize, total: header.totalSize

--- a/Sources/MacCleanKit/Models/ScanCategory.swift
+++ b/Sources/MacCleanKit/Models/ScanCategory.swift
@@ -108,6 +108,17 @@ public enum ScanCategory: String, CaseIterable, Identifiable, Sendable {
         }
     }
 
+    /// Full hover explanation for a category header.
+    ///
+    /// The header row renders the name and the subtitle on one truncating line
+    /// each, so a narrow window (or a long localization) hides the end of
+    /// either. The tooltip always carries both in full, which is the only place
+    /// a user can read what a category like "Broken Login Items" actually
+    /// contains before deciding to clean it.
+    public var tooltip: String {
+        "\(displayName)\n\(subtitle)"
+    }
+
     public var systemImage: String {
         switch self {
         case .userCaches, .systemCaches: "folder.badge.gearshape"

--- a/Tests/MacCleanKitTests/ScanCategoryTooltipTests.swift
+++ b/Tests/MacCleanKitTests/ScanCategoryTooltipTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+import Foundation
+
+@testable import MacCleanKit
+
+/// The results list shows a category's name and one-line explanation on
+/// truncating single lines, so the hover tooltip is what a user reads when
+/// either is cut off. These pin its content per category and per language.
+final class ScanCategoryTooltipTests: AppLanguageTestCase {
+
+    func testTooltipCarriesBothTheNameAndTheExplanation() {
+        AppLanguage.current = .en
+        for category in ScanCategory.allCases {
+            let tooltip = category.tooltip
+            XCTAssertTrue(
+                tooltip.contains(category.displayName),
+                "\(category.rawValue) tooltip must name the category"
+            )
+            XCTAssertTrue(
+                tooltip.contains(category.subtitle),
+                "\(category.rawValue) tooltip must explain what the category contains"
+            )
+        }
+    }
+
+    /// The name and the explanation must stay on separate lines; a tooltip that
+    /// ran them together would read as one sentence.
+    func testTooltipPutsTheExplanationOnItsOwnLine() {
+        AppLanguage.current = .en
+        for category in ScanCategory.allCases {
+            let lines = category.tooltip.components(separatedBy: "\n")
+            XCTAssertEqual(lines.count, 2, "\(category.rawValue) tooltip must be exactly two lines")
+            XCTAssertEqual(lines.first, category.displayName)
+            XCTAssertEqual(lines.last, category.subtitle)
+        }
+    }
+
+    /// The issue that prompted this: "Broken Login Items" says nothing about
+    /// what it deletes until you hover it.
+    func testBrokenLoginItemsTooltipExplainsWhatItDeletes() {
+        AppLanguage.current = .en
+        let tooltip = ScanCategory.brokenLoginItems.tooltip
+        XCTAssertEqual(
+            tooltip,
+            "Broken Login Items\nLogin items pointing at apps that are gone."
+        )
+    }
+
+    func testTooltipIsNeverEmptyOrPlaceholderInAnyLanguage() {
+        for language in AppLanguage.allCases {
+            AppLanguage.current = language
+            for category in ScanCategory.allCases {
+                let lines = category.tooltip.components(separatedBy: "\n")
+                XCTAssertEqual(lines.count, 2, "\(category.rawValue)/\(language.rawValue)")
+                for line in lines {
+                    XCTAssertFalse(
+                        line.trimmingCharacters(in: .whitespaces).isEmpty,
+                        "\(category.rawValue)/\(language.rawValue) tooltip has a blank line"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Every category gets its own tooltip; a copy-paste slip that gave two
+    /// categories the same explanation would be invisible in the UI.
+    func testEveryCategoryHasADistinctTooltip() {
+        AppLanguage.current = .en
+        let tooltips = ScanCategory.allCases.map(\.tooltip)
+        XCTAssertEqual(Set(tooltips).count, tooltips.count)
+    }
+}

--- a/Tests/MacCleanTests/FileTableViewTests.swift
+++ b/Tests/MacCleanTests/FileTableViewTests.swift
@@ -80,6 +80,19 @@ final class FileTableViewTests: XCTestCase {
         )
     }
 
+    /// A category header truncates its name and explanation to one line each,
+    /// so the tooltip is the only way to read them in full. Assert the cell the
+    /// table actually materializes carries it.
+    func testHeaderCellExposesTheCategoryTooltip() {
+        let coordinator = FileTableView.Coordinator()
+        coordinator.rows = makeRows(2)
+        let table = makeTable(coordinator: coordinator)
+        table.reloadData()
+
+        let headerCell = table.view(atColumn: 0, row: 0, makeIfNecessary: true)
+        XCTAssertEqual(headerCell?.toolTip, ScanCategory.userCaches.tooltip)
+    }
+
     func testRowHeightsAreFixedPerKind() {
         let coordinator = FileTableView.Coordinator()
         coordinator.rows = makeRows(2)


### PR DESCRIPTION
Closes #7.

## Summary

Hovering a junk-category header now shows what that category actually contains. Names like "Broken Login Items" are opaque on their own, and both the name and the one-line subtitle already in the header truncate to a single line, so a narrow window (or a long localization) hides the explanation.

## Changes

- `ScanCategory.tooltip` is `displayName` plus `subtitle` on two lines. Copy stays in one place so the list and the hover cannot drift.
- `HeaderCellView` sets `toolTip` from that string. `FileListView` is AppKit-backed (`FileTableView`) now, so SwiftUI `.help()` on the wrapper would not attach to the header cell — `NSView.toolTip` is the equivalent.

I did not add a separate `description` property. `subtitle` already is that one-line explanation, and `description` would collide with `CustomStringConvertible`.

## Test Plan

- [x] `ScanCategoryTooltipTests`: every category, every language, two non-empty lines; Broken Login Items pins the English copy that prompted the issue; tooltips are distinct.
- [x] `FileTableViewTests.testHeaderCellExposesTheCategoryTooltip`: the cell the table actually materializes carries the tooltip.
- [x] Red: empty `tooltip` stub → 6 tests / 367 assertion failures. Mutation: drop the `toolTip =` assignment → header cell `toolTip` is `nil`. Restored after each.
- [x] `swift build` → exit 0
- [x] `swift test` → **767 tests, 1 skipped, 0 failures** (the two commands CI runs)

## Screenshots

None. The tooltip is the system hover balloon (`NSView.toolTip`); it is not drawn in the row. The FileTableView test is the proof the header cell has the string.

## Choices worth your review

1. **Tooltip includes the name, not only the subtitle.** The issue asked for `.help(category.description)` with the explanation text. Name + explanation is more useful when the title itself is truncated.
2. **No new English strings.** Reused the existing localized `subtitle` values rather than duplicating 28 explanations.