### PR TITLE
Fix #141: add Excluded Folders in Settings

### DIFF
--- a/Sources/MacClean/Core/Scanner/ScanCoordinator.swift
+++ b/Sources/MacClean/Core/Scanner/ScanCoordinator.swift
@@ -98,14 +98,15 @@ public final class ScanCoordinator: @unchecked Sendable {
                 if Task.isCancelled { break }
                 // Drop items the current process couldn't trash even if it
                 // tried — root-owned children, data-vaulted Apple caches,
-                // stale paths. Users never see them, never click them,
+                // stale paths — and anything under a user-excluded folder
+                // (issue #141). Users never see them, never click them,
                 // never see "X errors" on the completion screen for things
                 // nothing on this machine could clean anyway. See
                 // CleanFilter for the syscall-level reasoning.
                 let scanResults: [ScanResult] = rawResults.map { result in
                     ScanResult(
                         category: result.category,
-                        items: result.items.filter { CleanFilter.isCleanableByCurrentProcess($0.url) },
+                        items: result.items.filter { CleanFilter.isActionable($0.url) },
                         autoSelect: result.autoSelect
                     )
                 }

--- a/Sources/MacClean/Modules/Duplicates/DuplicatesModule.swift
+++ b/Sources/MacClean/Modules/Duplicates/DuplicatesModule.swift
@@ -51,7 +51,7 @@ public struct DuplicatesModule: ScanModule {
         let files = items.filter { !$0.isDirectory }
         let duplicateGroups = await findDuplicates(files)
         let cleanableGroups = duplicateGroups.map { group in
-            group.filter { CleanFilter.isCleanableByCurrentProcess($0.url) }
+            group.filter { CleanFilter.isActionable($0.url) }
         }
         return DuplicateDetection.displayGroups(cleanableGroups)
     }

--- a/Sources/MacClean/Views/Settings/SettingsPageView.swift
+++ b/Sources/MacClean/Views/Settings/SettingsPageView.swift
@@ -30,6 +30,8 @@ struct SettingsPageView: View {
     @State private var keptLanguages: Set<String> = []
     @State private var selectable: [(name: String, lprojs: [String])] = []
     @State private var languageSearch: String = ""
+    @State private var excludedFolders: [String] = FolderExclusionPreferences.paths
+    @State private var exclusionError: String?
 
     /// Selectable languages filtered by the search field (case-insensitive).
     private var filteredLanguages: [(name: String, lprojs: [String])] {
@@ -44,6 +46,7 @@ struct SettingsPageView: View {
             interfaceLanguageSection
             appearanceSection
             languageSection
+            excludedFoldersSection
             aboutSection
         }
         .formStyle(.grouped)
@@ -53,6 +56,7 @@ struct SettingsPageView: View {
         .onAppear {
             keptLanguages = LanguagePreferences.userKept
             selectable = LanguagePreferences.selectableLanguages()
+            excludedFolders = FolderExclusionPreferences.paths
             Task.detached(priority: .userInitiated) {
                 let found = LanguageScanner().discoverLproj(in: LanguageScanner.defaultRoots)
                 await MainActor.run {
@@ -360,6 +364,101 @@ struct SettingsPageView: View {
                 }
                 .frame(height: 250)
             }
+        }
+    }
+
+    // MARK: - Excluded Folders (issue #141)
+
+    private var excludedFoldersSection: some View {
+        Section(L10n.tr("排除文件夹", "Excluded Folders", "Исключённые папки")) {
+            Text(L10n.tr(
+                "这些文件夹及其子项不会出现在清理扫描结果中，也无法被 \(MCConstants.appName) 删除（包括粉碎器）。仅限主目录或 /Volumes 下的路径。",
+                "These folders and their contents are hidden from cleanup scans and cannot be deleted by \(MCConstants.appName) (including Shredder). Only paths under your home folder or /Volumes.",
+                "Эти папки и их содержимое не показываются в сканах очистки и не могут быть удалены \(MCConstants.appName) (включая Шредер). Только пути в домашней папке или /Volumes."
+            ))
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            if excludedFolders.isEmpty {
+                Text(L10n.tr("尚未排除任何文件夹。", "No folders excluded yet.", "Пока нет исключённых папок."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(excludedFolders, id: \.self) { path in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(path)
+                            .font(.system(.body, design: .monospaced))
+                            .lineLimit(2)
+                            .textSelection(.enabled)
+                        Spacer(minLength: 8)
+                        Button(L10n.tr("移除", "Remove", "Удалить"), role: .destructive) {
+                            FolderExclusionPreferences.remove(path)
+                            excludedFolders = FolderExclusionPreferences.paths
+                            exclusionError = nil
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+            }
+
+            Button(L10n.tr("添加文件夹…", "Add Folder…", "Добавить папку…")) {
+                addExcludedFolder()
+            }
+
+            if let exclusionError {
+                Label(exclusionError, systemImage: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.caption)
+            }
+        }
+    }
+
+    private func addExcludedFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = L10n.tr("排除", "Exclude", "Исключить")
+        panel.message = L10n.tr(
+            "选择要从清理中排除的文件夹。",
+            "Choose a folder to exclude from cleanup.",
+            "Выберите папку, которую нужно исключить из очистки."
+        )
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        let path = url.path(percentEncoded: false)
+        if FolderExclusionPreferences.add(path) {
+            excludedFolders = FolderExclusionPreferences.paths
+            exclusionError = nil
+        } else {
+            exclusionError = rejectionMessage(for: path)
+        }
+    }
+
+    private func rejectionMessage(for path: String) -> String {
+        switch PathExclusion.candidateDecision(
+            for: path,
+            home: NSHomeDirectory(),
+            maxCount: FolderExclusionPreferences.defaultMaxCount,
+            existing: FolderExclusionPreferences.paths
+        ) {
+        case .allow:
+            return L10n.tr("无法添加该文件夹。", "Couldn't add that folder.", "Не удалось добавить эту папку.")
+        case .reject(.notAbsolute):
+            return L10n.tr("请选择绝对路径。", "Choose an absolute path.", "Выберите абсолютный путь.")
+        case .reject(.entireHome):
+            return L10n.tr("不能排除整个主目录。", "You can't exclude your entire home folder.", "Нельзя исключить всю домашнюю папку.")
+        case .reject(.entireVolumesRoot):
+            return L10n.tr("不能排除整个 /Volumes。", "You can't exclude all of /Volumes.", "Нельзя исключить весь /Volumes.")
+        case .reject(.outsideAllowedRoots):
+            return L10n.tr("只能排除主目录或 /Volumes 下的文件夹。", "Only folders under your home directory or /Volumes can be excluded.", "Можно исключать только папки в домашнем каталоге или /Volumes.")
+        case .reject(.atCapacity):
+            return L10n.tr(
+                "最多可排除 \(FolderExclusionPreferences.defaultMaxCount) 个文件夹。",
+                "You can exclude at most \(FolderExclusionPreferences.defaultMaxCount) folders.",
+                "Можно исключить не больше \(FolderExclusionPreferences.defaultMaxCount) папок."
+            )
+        case .reject(.alreadyCovered):
+            return L10n.tr("该路径已被现有排除项覆盖。", "That path is already covered by an existing exclusion.", "Этот путь уже покрыт существующим исключением.")
         }
     }
 

--- a/Sources/MacCleanKit/CleanFilter.swift
+++ b/Sources/MacCleanKit/CleanFilter.swift
@@ -52,21 +52,35 @@ public enum CleanFilter {
 
         return true
     }
+
+    /// True when the item is both writable by this process and outside
+    /// every user-excluded folder (issue #141).
+    public static func isActionable(
+        _ url: URL,
+        excludedFolders: [String] = FolderExclusionPreferences.paths
+    ) -> Bool {
+        isCleanableByCurrentProcess(url) && !PathExclusion.isExcluded(url, by: excludedFolders)
+    }
 }
 
 public extension Array where Element == ScanResult {
     /// Drops items the current process couldn't trash, per
-    /// `CleanFilter.isCleanableByCurrentProcess`. Producing modules
-    /// call this on their results before returning — that way every
-    /// caller (ScanCoordinator, each per-module ViewModel/View that
-    /// invokes `module.scan()` directly) sees a filtered set without
-    /// needing to know about the filter. The contract is: a
-    /// `ScanModule.scan()` only returns items the user can act on.
-    func filteringUncleanable() -> [ScanResult] {
+    /// `CleanFilter.isCleanableByCurrentProcess`, and items under user-
+    /// excluded folders (issue #141). Producing modules call this on their
+    /// results before returning — that way every caller (ScanCoordinator,
+    /// each per-module ViewModel/View that invokes `module.scan()` directly)
+    /// sees a filtered set without needing to know about the filter. The
+    /// contract is: a `ScanModule.scan()` only returns items the user can
+    /// act on.
+    func filteringUncleanable(
+        excludedFolders: [String] = FolderExclusionPreferences.paths
+    ) -> [ScanResult] {
         map { result in
             ScanResult(
                 category: result.category,
-                items: result.items.filter { CleanFilter.isCleanableByCurrentProcess($0.url) },
+                items: result.items.filter {
+                    CleanFilter.isActionable($0.url, excludedFolders: excludedFolders)
+                },
                 autoSelect: result.autoSelect
             )
         }

--- a/Sources/MacCleanKit/FolderExclusionPreferences.swift
+++ b/Sources/MacCleanKit/FolderExclusionPreferences.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Persisted list of folders the user asked Mac Sai never to scan or delete
+/// (issue #141). Mirrors `LanguagePreferences`: `UserDefaults` string array.
+/// Tests pass an injected suite / home path so they never touch the real prefs.
+public enum FolderExclusionPreferences {
+    public static let defaultsKey = "excludedFolders"
+    public static let defaultMaxCount = 50
+
+    /// Absolute folder paths currently excluded (normalized).
+    public static var paths: [String] {
+        get { paths(in: .standard) }
+        set { setPaths(newValue, in: .standard) }
+    }
+
+    public static func paths(in defaults: UserDefaults) -> [String] {
+        PathExclusion.normalized(defaults.stringArray(forKey: defaultsKey) ?? [])
+    }
+
+    public static func setPaths(_ paths: [String], in defaults: UserDefaults) {
+        defaults.set(PathExclusion.normalized(paths), forKey: defaultsKey)
+    }
+
+    /// Adds `path` if the candidate policy allows it. Returns false on reject.
+    @discardableResult
+    public static func add(
+        _ path: String,
+        defaults: UserDefaults = .standard,
+        homePath: String = NSHomeDirectory(),
+        maxCount: Int = defaultMaxCount
+    ) -> Bool {
+        let existing = paths(in: defaults)
+        switch PathExclusion.candidateDecision(
+            for: path,
+            home: homePath,
+            maxCount: maxCount,
+            existing: existing
+        ) {
+        case .allow:
+            let canonical = SafetyGuard.canonicalizeMacOSFirmlinks(
+                path.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            var next = existing.filter { !PathExclusion.isInside($0, root: canonical) }
+            next.append(canonical)
+            setPaths(next, in: defaults)
+            return true
+        case .reject:
+            return false
+        }
+    }
+
+    public static func remove(
+        _ path: String,
+        defaults: UserDefaults = .standard
+    ) {
+        let canonical = SafetyGuard.canonicalizeMacOSFirmlinks(path)
+        setPaths(paths(in: defaults).filter { $0 != canonical }, in: defaults)
+    }
+}

--- a/Sources/MacCleanKit/PathExclusion.swift
+++ b/Sources/MacCleanKit/PathExclusion.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Path-prefix exclusion matching for user-chosen folders (issue #141).
+///
+/// Pure: no FileManager. Roots are absolute path strings. Matching uses a
+/// `/` boundary (so `…/Caches` does not match `…/CachesEvil`) and the same
+/// firmlink canonicalize as `SafetyGuard` so `/var` and `/private/var` agree.
+public enum PathExclusion {
+
+    public enum RejectReason: Equatable, Sendable {
+        case notAbsolute
+        case entireHome
+        case entireVolumesRoot
+        case outsideAllowedRoots
+        case atCapacity
+        case alreadyCovered
+    }
+
+    public enum CandidateDecision: Equatable, Sendable {
+        case allow
+        case reject(RejectReason)
+    }
+
+    /// True if `path` is `root` or a descendant.
+    public static func isInside(_ path: String, root: String) -> Bool {
+        let p = SafetyGuard.canonicalizeMacOSFirmlinks(path)
+        let r = SafetyGuard.canonicalizeMacOSFirmlinks(root)
+        if p == r { return true }
+        let prefix = r.hasSuffix("/") ? r : r + "/"
+        return p.hasPrefix(prefix)
+    }
+
+    public static func isExcluded(path: String, by roots: [String]) -> Bool {
+        guard !roots.isEmpty else { return false }
+        return roots.contains { isInside(path, root: $0) }
+    }
+
+    public static func isExcluded(_ url: URL, by roots: [String]) -> Bool {
+        isExcluded(path: url.path(percentEncoded: false), by: roots)
+    }
+
+    /// Whether a folder path may be added to the exclusion list.
+    public static func candidateDecision(
+        for path: String,
+        home: String,
+        maxCount: Int = FolderExclusionPreferences.defaultMaxCount,
+        existing: [String] = []
+    ) -> CandidateDecision {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/"), !trimmed.isEmpty else {
+            return .reject(.notAbsolute)
+        }
+        let canonical = SafetyGuard.canonicalizeMacOSFirmlinks(trimmed)
+        let homeCanon = SafetyGuard.canonicalizeMacOSFirmlinks(home)
+
+        if canonical == homeCanon {
+            return .reject(.entireHome)
+        }
+        if canonical == "/Volumes" {
+            return .reject(.entireVolumesRoot)
+        }
+
+        let underHome = isInside(canonical, root: homeCanon)
+        let underVolumes = isInside(canonical, root: "/Volumes")
+        guard underHome || underVolumes else {
+            return .reject(.outsideAllowedRoots)
+        }
+
+        if existing.contains(where: { isInside(canonical, root: $0) }) {
+            return .reject(.alreadyCovered)
+        }
+        if existing.count >= maxCount {
+            return .reject(.atCapacity)
+        }
+        return .allow
+    }
+
+    /// Deduped, sorted, with descendants removed when an ancestor is present.
+    public static func normalized(_ paths: [String]) -> [String] {
+        let unique = Array(Set(paths.map {
+            SafetyGuard.canonicalizeMacOSFirmlinks(
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        }.filter { !$0.isEmpty })).sorted()
+
+        return unique.filter { path in
+            !unique.contains { other in
+                other != path && isInside(path, root: other)
+            }
+        }
+    }
+}

--- a/Sources/MacCleanKit/SafetyGuard.swift
+++ b/Sources/MacCleanKit/SafetyGuard.swift
@@ -14,6 +14,7 @@ public struct SafetyGuard: Sendable {
         case sipProtected(String)
         case outsideUserScope(String)
         case invalidPath(String)
+        case userExcluded(String)
 
         public var errorDescription: String? {
             switch self {
@@ -29,6 +30,8 @@ public struct SafetyGuard: Sendable {
                 L10n.tr("路径不在允许的用户范围内：\(path)", "Path is outside the allowed user scope: \(path)", "Путь находится за пределами разрешённой области пользователя: \(path)")
             case .invalidPath(let path):
                 L10n.tr("路径无效或包含非法字符：\(path)", "Path is invalid or contains illegal characters: \(path)", "Путь недействителен или содержит недопустимые символы: \(path)")
+            case .userExcluded(let path):
+                L10n.tr("路径位于排除文件夹中：\(path)", "Path is inside an excluded folder: \(path)", "Путь находится в исключённой папке: \(path)")
             }
         }
     }
@@ -57,9 +60,15 @@ public struct SafetyGuard: Sendable {
     /// 2. After resolving symlinks, the path does not fall inside any protected
     ///    prefix (`/System`, `/usr`, `/bin`, `/sbin`, etc.).
     /// 3. After resolving symlinks, the path does not fall inside `/System/` (SIP).
-    /// 4. If symlink resolution changed the first 3 path components, the symlink
+    /// 4. After resolving symlinks, the path is not under a user-excluded folder
+    ///    (issue #141). Inject `excludedFolders` in tests; production defaults
+    ///    to `FolderExclusionPreferences.paths`.
+    /// 5. If symlink resolution changed the first 3 path components, the symlink
     ///    is treated as suspicious (TOCTOU prevention).
-    public func validatePath(_ url: URL) throws {
+    public func validatePath(
+        _ url: URL,
+        excludedFolders: [String] = FolderExclusionPreferences.paths
+    ) throws {
         let original = url.path(percentEncoded: false)
 
         if original.isEmpty {
@@ -91,6 +100,11 @@ public struct SafetyGuard: Sendable {
             if resolvedCanonical.hasPrefix(protected + "/") || resolvedCanonical == protected {
                 throw SafetyError.protectedPath(resolvedPath)
             }
+        }
+
+        if PathExclusion.isExcluded(path: resolvedCanonical, by: excludedFolders)
+            || PathExclusion.isExcluded(path: originalCanonical, by: excludedFolders) {
+            throw SafetyError.userExcluded(resolvedPath)
         }
 
         if originalCanonical != resolvedCanonical {

--- a/Tests/MacCleanKitTests/CleanFilterTests.swift
+++ b/Tests/MacCleanKitTests/CleanFilterTests.swift
@@ -109,6 +109,25 @@ final class CleanFilterTests: XCTestCase {
             [.posixPermissions: 0o755], ofItemAtPath: locked.path)
     }
 
+    func testFilteringUncleanableDropsUserExcludedFolders() throws {
+        let excludedRoot = tmpRoot.appending(path: "keep-me")
+        try FileManager.default.createDirectory(at: excludedRoot, withIntermediateDirectories: true)
+        let inside = excludedRoot.appending(path: "offline.db")
+        FileManager.default.createFile(atPath: inside.path, contents: Data([1]))
+
+        let okRoot = tmpRoot.appending(path: "other")
+        try FileManager.default.createDirectory(at: okRoot, withIntermediateDirectories: true)
+        let okFile = okRoot.appending(path: "junk.cache")
+        FileManager.default.createFile(atPath: okFile.path, contents: Data([2]))
+
+        let keep = FileItem(url: inside, name: "offline.db", size: 1, allocatedSize: 1, isDirectory: false)
+        let droppable = FileItem(url: okFile, name: "junk.cache", size: 1, allocatedSize: 1, isDirectory: false)
+        let input = [ScanResult(category: .userCaches, items: [keep, droppable])]
+
+        let filtered = input.filteringUncleanable(excludedFolders: [excludedRoot.path])
+        XCTAssertEqual(filtered[0].items.map(\.name), ["junk.cache"])
+    }
+
     // MARK: Selected-size estimate (must match what Clean actually frees)
 
     func testSelectedSizeCountsEachURLOnce() {

--- a/Tests/MacCleanKitTests/PathExclusionTests.swift
+++ b/Tests/MacCleanKitTests/PathExclusionTests.swift
@@ -1,0 +1,222 @@
+import XCTest
+@testable import MacCleanKit
+
+final class PathExclusionTests: XCTestCase {
+
+    private let home = "/Users/tester"
+
+    // MARK: - Containment
+
+    func testExactRootIsExcluded() {
+        XCTAssertTrue(
+            PathExclusion.isExcluded(
+                path: "/Users/tester/Caches",
+                by: ["/Users/tester/Caches"]
+            )
+        )
+    }
+
+    func testDescendantIsExcluded() {
+        XCTAssertTrue(
+            PathExclusion.isExcluded(
+                path: "/Users/tester/Caches/com.example.app/offline.db",
+                by: ["/Users/tester/Caches"]
+            )
+        )
+    }
+
+    func testSiblingPrefixIsNotExcluded() {
+        XCTAssertFalse(
+            PathExclusion.isExcluded(
+                path: "/Users/tester/CachesEvil/x",
+                by: ["/Users/tester/Caches"]
+            )
+        )
+    }
+
+    func testUnrelatedPathIsNotExcluded() {
+        XCTAssertFalse(
+            PathExclusion.isExcluded(
+                path: "/Users/tester/Documents/a.txt",
+                by: ["/Users/tester/Caches"]
+            )
+        )
+    }
+
+    func testEmptyExclusionListNeverMatches() {
+        XCTAssertFalse(
+            PathExclusion.isExcluded(path: "/Users/tester/Caches", by: [])
+        )
+    }
+
+    func testFirmlinkFormsMatchEachOther() {
+        // /var and /private/var are the same on-disk location.
+        XCTAssertTrue(
+            PathExclusion.isExcluded(
+                path: "/private/var/folders/xx/tmp",
+                by: ["/var/folders/xx"]
+            )
+        )
+        XCTAssertTrue(
+            PathExclusion.isExcluded(
+                path: "/var/folders/xx/tmp",
+                by: ["/private/var/folders/xx"]
+            )
+        )
+    }
+
+    // MARK: - Candidate policy
+
+    func testHomeSubtreeIsAllowed() {
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(
+                for: "/Users/tester/Library/Caches/com.example",
+                home: home
+            ),
+            .allow
+        )
+    }
+
+    func testVolumesSubtreeIsAllowed() {
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(
+                for: "/Volumes/Backup/AppCache",
+                home: home
+            ),
+            .allow
+        )
+    }
+
+    func testHomeItselfIsRejected() {
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(for: home, home: home),
+            .reject(.entireHome)
+        )
+    }
+
+    func testVolumesRootIsRejected() {
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(for: "/Volumes", home: home),
+            .reject(.entireVolumesRoot)
+        )
+    }
+
+    func testSystemPathIsRejected() {
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(for: "/System/Library", home: home),
+            .reject(.outsideAllowedRoots)
+        )
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(for: "/usr/local", home: home),
+            .reject(.outsideAllowedRoots)
+        )
+    }
+
+    func testRelativePathIsRejected() {
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(for: "Caches/foo", home: home),
+            .reject(.notAbsolute)
+        )
+    }
+
+    func testEmptyPathIsRejected() {
+        XCTAssertEqual(
+            PathExclusion.candidateDecision(for: "", home: home),
+            .reject(.notAbsolute)
+        )
+    }
+
+    // MARK: - Normalize / prune
+
+    func testNormalizeDropsDescendantsWhenAncestorPresent() {
+        let normalized = PathExclusion.normalized(
+            [
+                "/Users/tester/Caches",
+                "/Users/tester/Caches/com.example",
+                "/Users/tester/Documents",
+            ]
+        )
+        XCTAssertEqual(
+            normalized,
+            ["/Users/tester/Caches", "/Users/tester/Documents"]
+        )
+    }
+
+    func testNormalizeDedupesAndSorts() {
+        let normalized = PathExclusion.normalized(
+            [
+                "/Users/tester/Documents",
+                "/Users/tester/Caches",
+                "/Users/tester/Documents",
+            ]
+        )
+        XCTAssertEqual(
+            normalized,
+            ["/Users/tester/Caches", "/Users/tester/Documents"]
+        )
+    }
+
+    // MARK: - Preferences (injected defaults)
+
+    func testPreferencesRoundTripThroughInjectedDefaults() {
+        let suite = "folder-exclusion-test-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            return XCTFail("could not open isolated defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertTrue(FolderExclusionPreferences.paths(in: defaults).isEmpty)
+
+        XCTAssertTrue(
+            FolderExclusionPreferences.add(
+                "/Users/tester/Library/Caches/com.example",
+                defaults: defaults,
+                homePath: home
+            )
+        )
+        XCTAssertEqual(
+            FolderExclusionPreferences.paths(in: defaults),
+            ["/Users/tester/Library/Caches/com.example"]
+        )
+
+        XCTAssertFalse(
+            FolderExclusionPreferences.add("/System/Library", defaults: defaults, homePath: home),
+            "system paths must be refused"
+        )
+        XCTAssertFalse(
+            FolderExclusionPreferences.add(home, defaults: defaults, homePath: home),
+            "entire home must be refused"
+        )
+
+        FolderExclusionPreferences.remove(
+            "/Users/tester/Library/Caches/com.example",
+            defaults: defaults
+        )
+        XCTAssertTrue(FolderExclusionPreferences.paths(in: defaults).isEmpty)
+    }
+
+    func testPreferencesRespectsMaxCount() {
+        let suite = "folder-exclusion-cap-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            return XCTFail("could not open isolated defaults suite")
+        }
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertTrue(
+            FolderExclusionPreferences.add("/Users/tester/a", defaults: defaults, homePath: home, maxCount: 2)
+        )
+        XCTAssertTrue(
+            FolderExclusionPreferences.add("/Users/tester/b", defaults: defaults, homePath: home, maxCount: 2)
+        )
+        XCTAssertFalse(
+            FolderExclusionPreferences.add("/Users/tester/c", defaults: defaults, homePath: home, maxCount: 2)
+        )
+        XCTAssertEqual(FolderExclusionPreferences.paths(in: defaults).count, 2)
+    }
+
+    func testSharedKeyStaysStable() {
+        XCTAssertEqual(FolderExclusionPreferences.defaultsKey, "excludedFolders")
+    }
+}

--- a/Tests/MacCleanKitTests/SafetyGuardTests.swift
+++ b/Tests/MacCleanKitTests/SafetyGuardTests.swift
@@ -257,13 +257,37 @@ final class SafetyGuardTests: XCTestCase {
         }
     }
 
+    // MARK: - User-excluded folders (issue #141)
+
+    func testUserExcludedFolderIsRefused() {
+        let excluded = "/Users/tester/Library/Caches/com.example"
+        let inside = URL(filePath: "\(excluded)/offline.db")
+        XCTAssertThrowsError(try sg.validatePath(inside, excludedFolders: [excluded])) {
+            guard case SafetyGuard.SafetyError.userExcluded = $0 else {
+                return XCTFail("Expected userExcluded, got \($0)")
+            }
+        }
+    }
+
+    func testPathOutsideExcludedFoldersStillValidates() {
+        let url = MCConstants.userCaches.appending(path: "ok.cache")
+        XCTAssertNoThrow(
+            try sg.validatePath(url, excludedFolders: ["/Users/tester/OtherApp"])
+        )
+    }
+
+    func testEmptyExcludedListDoesNotAffectValidation() {
+        let url = MCConstants.userCaches.appending(path: "ok.cache")
+        XCTAssertNoThrow(try sg.validatePath(url, excludedFolders: []))
+    }
+
     // MARK: - Idempotence
 
     func testValidatePathIsIdempotent() throws {
         let url = MCConstants.userCaches.appending(path: "test.cache")
-        XCTAssertNoThrow(try sg.validatePath(url))
-        XCTAssertNoThrow(try sg.validatePath(url))
-        XCTAssertNoThrow(try sg.validatePath(url))
+        XCTAssertNoThrow(try sg.validatePath(url, excludedFolders: []))
+        XCTAssertNoThrow(try sg.validatePath(url, excludedFolders: []))
+        XCTAssertNoThrow(try sg.validatePath(url, excludedFolders: []))
     }
 
     // MARK: - isProtectedApp

--- a/Tests/MacCleanTests/FolderExclusionSettingsTests.swift
+++ b/Tests/MacCleanTests/FolderExclusionSettingsTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+final class FolderExclusionSettingsTests: XCTestCase {
+
+    func testSettingsPageHasExcludedFoldersSection() throws {
+        let src = try String(contentsOf: sourceURL("Sources/MacClean/Views/Settings/SettingsPageView.swift"), encoding: .utf8)
+        XCTAssertTrue(src.contains("excludedFoldersSection"))
+        XCTAssertTrue(src.contains("FolderExclusionPreferences"))
+        XCTAssertTrue(
+            src.contains("cannot be deleted") || src.contains("无法被"),
+            "Copy must honestly say Mac Sai will not delete excluded folders"
+        )
+        XCTAssertFalse(
+            src.contains("revoke"),
+            "Do not overclaim capabilities"
+        )
+    }
+
+    func testScanCoordinatorUsesActionableFilter() throws {
+        let src = try String(contentsOf: sourceURL("Sources/MacClean/Core/Scanner/ScanCoordinator.swift"), encoding: .utf8)
+        XCTAssertTrue(
+            src.contains("CleanFilter.isActionable"),
+            "Coordinator second pass must honor user exclusions"
+        )
+    }
+
+    func testDuplicatesDisplayGroupsHonorExclusions() throws {
+        let src = try String(contentsOf: sourceURL("Sources/MacClean/Modules/Duplicates/DuplicatesModule.swift"), encoding: .utf8)
+        XCTAssertTrue(
+            src.contains("CleanFilter.isActionable"),
+            "Duplicates display groups must drop excluded copies"
+        )
+    }
+
+    func testSafetyGuardDefinesUserExcluded() throws {
+        let src = try String(contentsOf: sourceURL("Sources/MacCleanKit/SafetyGuard.swift"), encoding: .utf8)
+        XCTAssertTrue(src.contains("case userExcluded"))
+        XCTAssertTrue(src.contains("PathExclusion.isExcluded"))
+    }
+
+    private func sourceURL(_ relative: String) -> URL {
+        URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appending(path: relative)
+    }
+}

--- a/docs/superpowers/plans/2026-09-03-folder-exclusions.md
+++ b/docs/superpowers/plans/2026-09-03-folder-exclusions.md
@@ -1,0 +1,42 @@
+# Folder Exclusions (#141) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Settings list of folders that scans hide and SafetyGuard refuses to delete.
+
+**Architecture:** Pure `PathExclusion` + `FolderExclusionPreferences` in Kit; `CleanFilter` + `SafetyGuard` honor the list; Settings UI + coordinator/duplicates wiring in MacClean.
+
+**Tech Stack:** Swift 6, SwiftUI, XCTest, UserDefaults, NSOpenPanel
+
+## Global Constraints
+
+- One feature per PR (CONTRIBUTING).
+- Business logic in MacCleanKit; I/O (panel) stays in MacClean.
+- Deletion only via SafetyGuard + CleaningEngine.
+- No `password` / `secret` / `api_key` / `token` in `Sources/`.
+- New strings via `L10n.tr(zh, en, ru)`.
+- Do not modify `MCConstants.protectedPaths` system list.
+
+## Files
+
+| File | Role |
+|---|---|
+| `Sources/MacCleanKit/PathExclusion.swift` | Prefix match + candidate policy |
+| `Sources/MacCleanKit/FolderExclusionPreferences.swift` | Persist / normalize list |
+| `Sources/MacCleanKit/CleanFilter.swift` | Drop excluded from scan results |
+| `Sources/MacCleanKit/SafetyGuard.swift` | Refuse delete of excluded |
+| `Sources/MacClean/Views/Settings/SettingsPageView.swift` | UI section |
+| `Sources/MacClean/Core/Scanner/ScanCoordinator.swift` | Same filter as modules |
+| `Sources/MacClean/Modules/Duplicates/DuplicatesModule.swift` | Display groups honor exclusions |
+| `Tests/MacCleanKitTests/PathExclusionTests.swift` | Policy + prefs |
+| `Tests/MacCleanKitTests/CleanFilterTests.swift` | Exclusion drop |
+| `Tests/MacCleanKitTests/SafetyGuardTests.swift` | userExcluded |
+| `Tests/MacCleanTests/FolderExclusionSettingsTests.swift` | Source guards |
+
+## Tasks
+
+- [x] RED/GREEN: PathExclusion + FolderExclusionPreferences
+- [x] RED/GREEN: CleanFilter + SafetyGuard
+- [x] Wire Settings, ScanCoordinator, Duplicates
+- [x] Source guards + full `swift test` + secrets grep (830 passed, 3 skipped, 0 failures)
+- [ ] PR Fixes #141

--- a/docs/superpowers/specs/2026-09-03-folder-exclusions-design.md
+++ b/docs/superpowers/specs/2026-09-03-folder-exclusions-design.md
@@ -1,0 +1,66 @@
+# Folder exclusion list (#141)
+
+Date: 2026-09-03
+Status: Design (approved for implementation)
+
+## Problem
+
+Users want specific folders never touched by Mac Sai scans or cleanup
+(e.g. an app’s offline cache). Issue #141 asks for a Settings list of
+folder paths to exclude.
+
+## Goal
+
+Settings → **Excluded Folders**: add/remove absolute folder paths. Those
+paths (and descendants) never appear in cleanup scan results and cannot
+be deleted through CleaningEngine / Shredder / any SafetyGuard caller.
+
+## Non-goals
+
+- No SpaceLens browse hiding (browse-only module).
+- No Uninstaller UI filtering of leftover rows (delete still refused).
+- No security-scoped bookmarks / sandbox entitlements changes.
+- No `Localizable.strings`; new copy uses `L10n.tr(zh, en, ru)`.
+- Do not claim exclusions survive a full-disk wipe or other apps.
+
+## Scope decisions
+
+| Topic | Choice |
+|---|---|
+| Effect | Scan filter **and** SafetyGuard delete refusal (incl. Shredder) |
+| Allowed roots | Under `$HOME` or `/Volumes/…` only |
+| Matching | Path prefix with `/` boundary + firmlink canonicalize |
+| Persistence | `UserDefaults.standard` string array (like `LanguagePreferences`) |
+| Cap | 50 folders; refuse excluding `$HOME` itself or `/Volumes` root |
+
+## Approach
+
+Pure Kit:
+
+1. **`PathExclusion`** — `isInside(path, root:)`, `isExcluded(url, by:)`,
+   normalize/canonicalize via `SafetyGuard.canonicalizeMacOSFirmlinks`.
+2. **`FolderExclusionPreferences`** — load/store paths; `candidateDecision`
+   for Add (allow / reject reason); prune descendants when an ancestor is
+   already listed; injectable `UserDefaults` + home path for tests.
+3. **`CleanFilter`** — `filteringUncleanable` also drops excluded URLs
+   (injected `excludedFolders` defaulting to prefs).
+4. **`SafetyGuard`** — new `SafetyError.userExcluded`; `validatePath`
+   accepts optional `excludedFolders` (defaults to prefs).
+
+MacClean:
+
+- Settings section: list + Add (NSOpenPanel, directories only) + Remove.
+- `ScanCoordinator` second-pass filter uses the same CleanFilter helper.
+- `DuplicatesModule.scanDisplayGroups` also drops excluded cleanable copies.
+
+## Honest product copy
+
+Buttons and caption say excluded folders are skipped by scans and **cannot
+be deleted** by Mac Sai. They do not protect against other apps or Finder.
+
+## Testing
+
+Kit unit tests for path matching (boundary, firmlinks, home vs volumes,
+reject system / home itself), prefs round-trip, CleanFilter drop, SafetyGuard
+refusal. Source guard that Settings mentions excluded folders. No live
+NSOpenPanel in tests.


### PR DESCRIPTION
## Summary
Adds **Settings → Excluded Folders** so users can mark specific folders that Mac Sai must never scan for cleanup or delete (issue #141).

Use case: protect an app’s offline cache (or any other directory) so a cleanup pass cannot touch it. Exclusions cover the folder and all descendants.

**What this does**
- Hides matching paths from cleanup scan results (`CleanFilter` / Smart Scan modules / Duplicates display groups).
- Refuses deletion via `SafetyGuard` (CleaningEngine, Shredder, any other validatePath caller) with `SafetyError.userExcluded`.

**What this does not claim**
- Does not hide paths in SpaceLens (browse-only).
- Does not filter Uninstaller leftover *rows* in the UI (delete is still refused).
- Does not protect against Finder or other apps.
- Only paths under the home folder or `/Volumes/…` can be added (not `/System`, not the entire home, not `/Volumes` itself). Cap: 50 folders.

Design: `docs/superpowers/specs/2026-09-03-folder-exclusions-design.md`.

## Changes
- `PathExclusion` (MacCleanKit) — prefix match with `/` boundary + firmlink canonicalize; candidate allow/reject policy
- `FolderExclusionPreferences` — `UserDefaults` string array (same pattern as `LanguagePreferences`); injected defaults in tests
- `CleanFilter.isActionable` / `filteringUncleanable` — also drops excluded URLs
- `SafetyGuard` — `userExcluded` error; injectable `excludedFolders` for tests
- Settings section — list, Add Folder… (`NSOpenPanel`), Remove, honest rejection messages
- `ScanCoordinator` + `DuplicatesModule.scanDisplayGroups` use `isActionable`

## Test Plan
- [x] `swift test` — **830 passed**, 3 skipped, **0 failures**
- [x] `PathExclusionTests` — containment boundary, firmlinks, home/volumes allow, reject system/home/`/Volumes`, prune descendants, prefs round-trip, max count
- [x] `CleanFilterTests` — excluded writable files dropped from scan results
- [x] `SafetyGuardTests` — `userExcluded` refused; empty list unchanged
- [x] Source guards — Settings section + coordinator/duplicates/`userExcluded` wiring
- [x] CI secrets grep on `Sources/*.swift` — clean
- [ ] In the running app: Settings → Add a cache folder → System Junk / Large Files scan no longer lists files under it; Shredder on a file inside it fails with the excluded-folder error; Remove restores scan visibility

## Checklist
- [x] Code compiles (`swift test`)
- [x] Follows existing style (Swift 6, Kit policy + thin UI, `L10n.tr`)
- [x] No telemetry or extra network calls
- [x] PR is focused (one feature: #141)
- [x] Honest scope (no overclaim about SpaceLens / other apps)

Fixes #141